### PR TITLE
docs: organize & sync roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Aura is built on a foundation of independent actors:
 2. **Storage Engine**: Manages high-speed asynchronous disk I/O, write aggregation, and atomic file completion.
 3. **Protocol Workers**: Lightweight, specialized actors for HTTP, BitTorrent, and FTP that handle protocol-specific logic and data retrieval.
 
-See [design.md](./design.md) for a deep dive into the system design and [CONTEXT.md](./CONTEXT.md) for our ubiquitous language.
+See [design.md](docs/project/design.md) for a deep dive into the system design and [CONTEXT.md](docs/project/CONTEXT.md) for our ubiquitous language.
 
 ## 🤝 Contributing
-Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for our engineering standards and TDD workflow.
+Please read [CONTRIBUTING.md](docs/project/CONTRIBUTING.md) for our engineering standards and TDD workflow.
 
 ## 📜 License
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/docs/project/CONTEXT.md
+++ b/docs/project/CONTEXT.md
@@ -1,0 +1,208 @@
+# Context: Aura
+
+The Rust-based successor to aria2, focusing on high-performance, asynchronous download orchestration using an actor-based architecture.
+
+## Glossary
+
+### User & Orchestration
+#### Download Task
+The atomic unit of user-facing control (pause, resume, delete). It represents a single logical download operation. A task is **Phase-aware**, transitioning from **Metadata Exchange** to the active downloading phase once it has "matured" and the full file structure is known.
+
+#### Orchestrator
+The central coordinator (also referred to as the **Manager**) responsible for the lifecycle of **Download Tasks**, handling external RPC requests, and mediating between different **Protocol Workers**. It serves as the **Source of Truth** for the entire system.
+
+#### Persona Switcher
+A bootstrap component that determines the engine's operation mode (**CLI**, **TUI**, or **Daemon**) based on command-line flags.
+
+#### RPC Server
+A multi-protocol gateway (JSON-RPC, WebSocket) that enables **Remote Attachment** for the TUI and integration with third-party Web UIs.
+
+#### Themeable TUI
+An interactive terminal interface built on **Ratatui** that supports customizable visual themes.
+
+#### Browser Bridge
+A specialized component that intercepts download requests from web browsers and funnels them into the **Orchestrator**.
+
+#### Engine API
+The public Rust-native interface for `Aura`, optimized for direct integration into other Rust applications.
+
+#### Hook Manager
+A lifecycle orchestration service that executes user-defined actions triggered by task state changes.
+
+#### Lifecycle Controller
+A high-level service that monitors the engine and executes automated system-level actions (e.g., shutdown) once all tasks are complete.
+
+#### Conflict Handler
+The component responsible for resolving file name collisions using policies like **Overwrite**, **Auto-rename**, or **Skip**.
+
+#### Chain Orchestrator
+A high-level logic that allows one **Download Task** to spawn another (e.g., HTTP -> BitTorrent).
+
+#### Temporal Scheduler
+A service that allows users to define time-based policies for **Download Tasks**.
+
+#### Recursive Crawler
+A specialized logic (parity with `wget -m`) that parses HTML/CSS files to discover and enqueue further links.
+
+#### Stream Output Handler
+A component that allows downloaded data to be piped directly to `stdout`.
+
+#### Tenant Context
+An isolation layer that associates **Download Tasks** with specific users, enforcing per-user permissions and quotas.
+
+#### Shutdown Coordinator
+A system-level service that manages the graceful exit of the engine, ensuring all data is flushed and states are saved.
+
+#### Landing Page Resolver
+An advanced logic layer that identifies when a URI points to a web page containing a download link rather than the file itself. It uses the **Recursive Crawler**'s logic to find the "Direct Link" automatically.
+
+### Core Engine & Strategy
+#### Piece Selector
+A strategy-based component within the **Orchestrator** that determines the next optimal **Piece** to be fetched. It supports **Bi-directional Signaling** for work assignment and cancellation.
+
+#### Work Stealer
+Logic within the **Piece Selector** that identifies slow network streams using a **Performance Delta** and employs a **Racing** strategy.
+
+#### Segmenter
+The component responsible for partitioning continuous byte-streams (HTTP/FTP). It uses the **Boundary Aligner** to ensure its virtual **Pieces** are compatible with multi-source downloads.
+
+#### Boundary Aligner
+A coordination logic within the **Sourced Aggregator**. It ensures that segments fetched from non-pieced protocols (like HTTP) align exactly with the piece boundaries defined in the master metadata.
+
+#### Policy Manager
+A decision-making component that governs the lifecycle of tasks, handling **Self-healing** and retries.
+
+#### Seeding Policy Manager
+A decision-making component that governs the duration and limits of the **Seeding** phase.
+
+#### Error Classification
+The categorization of failures into **Worker Error**, **Task Error**, and **Engine Error** scopes.
+
+#### Global Token Bucket Throttler
+A centralized rate-limiting component that independently controls global, per-tenant, and per-task speeds.
+
+#### URL Globber
+A pre-processor that expands pattern-based URIs (e.g., `[1-100]`) into a batch of individual tasks.
+
+#### Integrity Scrubber
+A maintenance service that performs background validation of local data to identify and fix corrupt pieces.
+
+#### Generation Tracker
+A versioning system that assigns monotonic **Generation IDs** to piece assignments to prevent "Zombie Writes" during racing.
+
+#### Sequential Aggregator
+A component within the **Storage Engine** that reorders write requests to facilitate large, sequential disk writes.
+
+#### Rot-Detection Daemon
+A background service that periodically re-verifies completed downloads to detect "Bit Rot" over time.
+
+### Security, Safety & Privacy
+#### Sandbox Root
+A mandatory security boundary within the **Resource Mapper**. All paths are resolved relative to this root, and traversal attempts are strictly neutralized.
+
+#### Path Normalizer
+A utility that ensures filenames are compatible with the target filesystem (Unicode normalization, case-folding, and reserved character removal).
+
+#### Traffic Kill-switch
+A privacy feature within the **Interface Binder** that halts all network operations if a bound VPN interface becomes unavailable.
+
+#### Secret Scrubber
+A security utility that automatically redacts sensitive information (passwords, API keys) from logs and telemetry events.
+
+#### Backpressure Controller
+A safety mechanism that manages actor mailbox sizes and pauses data ingestion when the storage engine is congested to prevent OOM.
+
+#### Resource Governor
+A system-level service that enforces hard limits on metadata size, recursion depth, and concurrent connections. It includes a **Dangerous Port Filter**.
+
+#### Dangerous Port Filter
+A security mechanism within the **Resource Governor** that blocks outbound connections to sensitive system ports (e.g., SMTP/25, SSH/22).
+
+#### Hash Throttler
+A security component that rate-limits CPU-intensive integrity checks to prevent "Hashing DoS" attacks.
+
+#### Punycode Normalizer
+A utility within the **Privacy-Enhanced Resolver** that converts IDNs to ASCII and flags visually deceptive domains using a **Homograph Detector**.
+
+#### Captive Portal Detector
+A networking safeguard that validates incoming HTTP responses against expected MIME types and file sizes. It prevents the engine from silently saving HTML login pages when operating on restricted public networks.
+
+#### MIME Validator
+A safety safeguard that inspects the `Content-Type` header of an incoming stream. It ensures that the received data matches the expected file type (e.g., rejecting `text/html` when the user expects an `application/octet-stream`).
+
+### Networking & Protocols
+#### Protocol Worker
+An asynchronous actor specialized in a specific protocol (HTTP, BitTorrent, FTP, NNTP). It operates on an **Orchestrated Pull** model with **Abort Signaling** and manages **Redirect Chains**.
+
+#### Redirect Manager
+A coordination component within the **Protocol Worker** (specifically HTTP) that manages 3xx status codes. It ensures that redirect chains are followed safely, prevents infinite loops, and maintains security boundaries.
+
+#### Proxy Connector
+An abstraction layer for establishing network connections through intermediaries (HTTP, SOCKS5, VPN).
+
+#### Privacy-Enhanced Resolver
+A networking service supporting **Async DNS**, **DNS over HTTPS (DoH)**, and local caching.
+
+#### Happy Eyeballs
+A dual-stack connection algorithm (RFC 8305) used to minimize latency by attempting IPv4 and IPv6 connections simultaneously.
+
+#### Credential Provider
+A service that resolves authentication data from `netrc`, cookies, and secure keychains.
+
+#### Peer Discovery Actor
+A background service (DHT, PEX, Trackers, LPD) responsible for finding new peers.
+
+#### Peer Registry
+A per-task component that maintains known peers and tracks **Peer Reputation**.
+
+#### Traffic Obfuscator
+A privacy component within the BitTorrent **Protocol Worker** that implements Message Stream Encryption (MSE/PE). It masks P2P traffic from Deep Packet Inspection (DPI) by ISPs.
+
+### Storage & Data
+#### Storage Engine
+A centralized service that manages all disk I/O, supporting **Buffered I/O** (via the aggregator) and **Mapped I/O**. It includes the **Piece-Buffer Journal**.
+
+#### Piece-Buffer Journal
+A persistent temporary store in the **Storage Engine** that saves partial, unverified pieces across restarts to prevent progress regression.
+
+#### Journaled State Store
+A robust implementation of state persistence that uses an atomic "write-then-swap" strategy to prevent metadata corruption.
+
+#### Boundary Splitter
+A logic component that handles **Pieces** spanning multiple physical files.
+
+#### Bit-Bucket File
+A virtual file entry in the **Resource Mapper** used for **Padding Files** (BEP 47), avoiding physical junk file creation.
+
+#### Pre-allocation
+The process of reserving total disk space at task start to prevent fragmentation and mid-download failure.
+
+#### Atomic Completion
+The strategy of writing to a `.part` file and only renaming to the target name after 100% verification.
+
+#### Merkle Tree Store
+A specialized database for managing the hierarchical hash trees required by BitTorrent v2.
+
+#### Buffer Pool
+A centralized memory management system for caching piece data and enabling **Zero-Copy Path** operations.
+
+#### Disk I/O Scheduler
+A component that optimizes disk operations using **Async I/O (io-uring)** and **FADV Strategy**.
+
+#### Resource Mapper
+A per-task component that maps logical file structures to physical paths, supporting renaming and mirroring.
+
+#### Filesystem Adapter
+A component that detects storage capabilities (NFS/SMB, sparse files) and applies **Adaptive I/O**. It uses an **Allocation Prober** for performance diagnostics.
+
+#### Allocation Prober
+A diagnostic tool within the **Filesystem Adapter** that performs "test writes" to determine the true performance of the filesystem's allocation method.
+
+#### Mirroring Mode
+An operational state for Cloud Adapters that synchronizes local directories with remote sources (parity with `rclone sync`).
+
+#### COW-Aware Allocator
+A specialized logic within the **Filesystem Adapter** that detects Copy-On-Write filesystems (e.g., ZFS, Btrfs). It dynamically alters the **Pre-allocation** strategy to prevent fragmentation.
+
+#### Kernel TLS (kTLS)
+An advanced optimization utilized by the **Zero-Copy Path**. It offloads HTTPS/TLS decryption to the kernel or network hardware.

--- a/docs/project/CONTRIBUTING.md
+++ b/docs/project/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to Aura
+
+Thank you for your interest in contributing to the next generation of high-performance downloaders!
+
+## 🧠 Engineering Standards
+We maintain a high bar for code quality. All contributions must adhere to:
+1. **Expert Rust Specialist Principles**: Safety first, idiomatic expressiveness, and zero-cost abstractions.
+2. **Mandatory TDD Workflow**:
+    - **Red**: Every PR must include a failing test that demonstrates the new feature or bug.
+    - **Green**: Implementation code must make the test pass.
+    - **Refactor**: Code must be cleaned and optimized before submission.
+3. **No Panics**: Use `Result` and `Error` types. Never use `unwrap()` or `expect()` in library code.
+
+## 🏗️ Pull Request Protocol
+- **ADRs**: Significant architectural changes require a new Architecture Decision Record in `docs/adr/`.
+- **Glossary**: Update `CONTEXT.md` if you introduce new domain concepts.
+- **Verification**: Run `cargo test` and `cargo clippy -- -D warnings` before submitting.

--- a/docs/project/GEMINI.md
+++ b/docs/project/GEMINI.md
@@ -1,0 +1,19 @@
+# Aura: Project Mandates
+
+This document defines the foundational mandates for Gemini CLI when working on the `Aura` project. These instructions take absolute precedence over all other defaults.
+
+## ⚙️ Engineering Standards
+- **Rust Excellence**: Adhere strictly to the "Expert Rust Specialist" principles: no panics, structured error handling with `thiserror`, type safety via newtypes, and idiomatic async patterns.
+- **Actor Integrity**: Maintain strict decoupling between the Orchestrator, Storage Engine, and Protocol Workers. All communication must happen via type-safe channels.
+- **Performance First**: Prioritize zero-copy paths and asynchronous I/O. Every significant I/O or architectural change must be accompanied by an ADR.
+
+## 🛡️ Security & Safety
+- **Credential Protection**: The `Secret Scrubber` must be used for all telemetry and logging. Never log full URIs if they contain user:pass.
+- **Sandboxing**: All file operations must be validated against the `Sandbox Root`.
+- **VPN Safety**: The `Traffic Kill-switch` mandate (ADR 0035) must be enforced for any task bound to a specific interface.
+
+## 🏗️ Workflow Mandates
+- **TDD Workflow**: Always follow the Red-Green-Refactor cycle. A task is not started until a failing test (RED) exists, and not finished until the test passes (GREEN) and the code is idiomatic (REFACTOR).
+- **Validation**: Every implementation task (Milestone) is incomplete without comprehensive unit tests in the core and behavioral verification via the CLI persona.
+- **Git Protocol**: Never stage or commit changes unless explicitly instructed with the exact phrase: "Commit these changes".
+- **Documentation**: Update `CONTEXT.md` immediately when new domain terms are introduced and maintain the ADR sequence in `docs/adr/`.

--- a/docs/project/LEARNINGS.md
+++ b/docs/project/LEARNINGS.md
@@ -1,0 +1,22 @@
+# Aura: Project Learnings & Analysis
+
+## Overview
+`Aura` is the high-performance, asynchronous Rust successor to `aria2`. It utilizes an actor-based architecture to provide a safer, more concurrent, and more maintainable download orchestration engine.
+
+## Engineering Baseline
+- **Language**: Rust (Edition 2021).
+- **Runtime**: `tokio` (Multi-threaded async).
+- **Communication**: Actor model using `mpsc` for commands and `broadcast` for telemetry.
+- **I/O Engine**: Modular Storage Engine targeting `io_uring` for extreme throughput.
+
+## Milestone Progress
+
+### Milestone 2: The "Smart" Buffer (Completed)
+- **Atomic Completion**: Writing to `.part` files and renaming only after 100% verification prevents the "partial file" corruption common in standard downloaders.
+- **Sequential Aggregation**: Reordering writes in memory before flushing to disk is critical for BitTorrent performance on physical disks (HDDs).
+- **Iron-Clad Networking**: Standard HTTP clients are too permissive for download managers. Implementing manual redirect management and **Content Sniffing** (identifying HTML even when the server lies about MIME types) is mandatory for robustness.
+- **TDD with Wiremock**: Using `wiremock` for actor integration tests allows simulating hostile network environments (redirect loops, slow streams) that are difficult to reproduce with real servers.
+
+### Milestone 6: Persistence & Advanced Protocols (In Progress)
+- **Task Persistence Architecture**: Saving task state (`.aura` files) allows for session recovery. The most complex part is reconstructing the **BitTorrent Piece Picker** and **Global Bitfield** from disk to avoid re-downloading validated data.
+- **NAT Traversal Resilience**: Production-grade BitTorrent requires reachability. Implementing a dual-stack fallback (UPnP via `igd-next` and NAT-PMP/PCP via `crab_nat`) ensures the client is connectable in most consumer network environments. Discovery of the gateway IP is a prerequisite; while UPnP handles this internally, NAT-PMP/PCP often requires manual gateway detection or assuming the `.1` address in the local subnet.

--- a/docs/project/MODERN_BT_GAPS.md
+++ b/docs/project/MODERN_BT_GAPS.md
@@ -1,0 +1,35 @@
+# BitTorrent Feature Gaps: aria2 vs. Modern Clients
+
+While aria2 is an exceptionally fast and lightweight multi-protocol tool, it lacks several features found in modern, specialized BitTorrent clients (like qBittorrent, Transmission, or BiglyBT).
+
+## 1. BitTorrent v2 (BEP 52) Support
+*   **Status**: **Missing**
+*   **Details**: Modern clients are moving towards the BitTorrent v2 specification, which uses SHA-256 for piece hashes and a Merkle tree structure. aria2 currently only supports BitTorrent v1 (SHA-1).
+
+## 2. Automatic Port Forwarding (UPnP / NAT-PMP)
+*   **Status**: **Missing**
+*   **Details**: aria2 does not automatically negotiate port forwarding with routers. Users must manually forward ports (default 6881-6999) or rely on a pre-configured network environment.
+
+## 3. IP Filtering / Blocklists
+*   **Status**: **Limited/Missing**
+*   **Details**: Many modern clients allow loading an `ipfilter.dat` or similar blocklist to automatically ban known malicious or "anti-p2p" IPs. aria2 lacks a native, easy-to-use IP blocklist feature for peers.
+
+## 4. Built-in Search & RSS
+*   **Status**: **Missing**
+*   **Details**: There is no native RSS feed aggregator or torrent search engine integration. These must be handled by external scripts or frontends via the RPC interface.
+
+## 5. Peer Exchange (PEX) & DHT Nuances
+*   **Status**: **Supported**, but lacks the fine-grained control found in GUI clients (e.g., manual peer adding, easy tracker swapping, or per-tracker statistics).
+
+## 6. Web UI Integration
+*   **Status**: **External Only**
+*   **Details**: aria2 provides a powerful RPC interface but no built-in Web UI. Users must host or use a separate frontend like AriaNg, webui-aria2, or yaaw.
+
+## 7. Advanced Seeding Management
+*   **Status**: **Limited**
+*   **Details**: While it supports `--seed-time` and `--seed-ratio`, it lacks advanced features like "Super Seeding" (Initial Seeding) and fine-grained control over seeding priority based on health.
+
+---
+
+### Conclusion
+aria2 is optimized for **automation, speed, and low resource usage**. It is often used as a "backend engine" for other applications. For a traditional "desktop" torrenting experience with privacy blocklists and automatic port configuration, a dedicated BitTorrent client is still superior.

--- a/docs/project/TASKS.md
+++ b/docs/project/TASKS.md
@@ -1,0 +1,67 @@
+# Aura: Project Tasks & Roadmap
+
+## ✅ Milestone 1: The Atomic Download (Completed)
+- [x] Basic Actor Skeleton (Orchestrator, StorageEngine).
+- [x] Protocol Abstraction (`ProtocolWorker` trait).
+- [x] HTTP Single-source retrieval.
+- [x] Engine API for high-level control.
+- [x] Basic CLI Persona (`Aura-cli`).
+
+## ✅ Milestone 2: The "Smart" Buffer (Completed)
+- [x] Real Disk I/O with `tokio::fs`.
+- [x] Atomic Completion (`.part` file rename logic).
+- [x] Sequential Write Aggregation (in-memory reordering).
+- [x] Buffer Pool (memory reuse).
+- [x] Bi-directional Actor Signaling (Storage -> Orchestrator completion).
+
+## 🚀 Milestone 3: The Swarm (BitTorrent)
+- [x] **Bitfield Implementation** (TDD: Unit tests first).
+- [x] **Piece Selection Logic** (Rarest-First strategy).
+- [x] **BitTorrent Protocol Worker** (Handshake, Message parsing, Codec).
+- [x] **Torrent File Parsing** (Bencode, InfoHash).
+- [x] **Tracker Client** (Robust UDP, HTTP Announce, Multi-IP support).
+- [x] **Piece Hash Verification** (SHA-1 integrity checks).
+- [x] **Peer Registry** (Managing peer state and lifecycle).
+- [x] **Request Pipelining** (High-speed concurrent requests).
+- [x] **DHT/PEX Actors** (Advanced peer discovery).
+- [x] **Seeding Mode**.
+- [ ] **Magnet Link Support** (BEP 9 Metadata Exchange).
+- [ ] **Local Peer Discovery (LPD)** (Multicast discovery).
+
+## ✅ Milestone 4: Hyper-Scale (Aggregator) (Completed)
+- [x] **Sourced Aggregator** (Multi-protocol task merging).
+- [x] **Work Stealing & Racing** (Speculative execution).
+- [ ] **Endgame Mode** (Parallel final block fetching).
+- [x] **Adaptive Connection Scaling** (Bypassing per-connection caps).
+- [x] **Hierarchical Throttling** (Global + Per-task speed limits).
+
+## ✅ Milestone 5: Personas & UX (In Progress)
+- [x] **RPC Server** (Axum/JSON-RPC 2.0).
+- [x] **Themeable TUI** (Ratatui + JSON-RPC client).
+- [ ] **Public Rust API** (TaskHandles & Streams).
+- [ ] **Browser Bridge** (Extension support).
+- [x] **Headless Daemon Mode** (`Aura-daemon`).
+
+## 🚀 Milestone 6: Persistence & Advanced Protocols
+- [x] **Pause/Resume Support** (Stopping and restarting downloads).
+- [x] **Task Persistence** (Control files for session recovery).
+- [x] **NAT Traversal** (UPnP/NAT-PMP for seeding).
+- [ ] **BitTorrent v2** (Merkle-tree based integrity).
+- [x] **URL Globbing & Batch Downloads**.
+- [x] **FTP Protocol Support**.
+- [x] **VPN Safety & Traffic Kill-switch** (ADR 0035).
+- [x] **Dynamic TOML Configuration** (Aura.toml + Hot-reloading).
+- [x] **Modular Architecture Refactor** (No file > 400 lines).
+- [ ] **VPN Native Integration** (OpenVPN/WireGuard support) (ADR 0038).
+- [ ] **Power Management** (OS-level sleep assertions).
+- [ ] **No-COW Allocator** (Btrfs/ZFS fragmentation prevention).
+- [ ] **Recursive Mirroring** (Wget-style site crawling).
+
+## 🛡️ Infrastructure & DevSecOps
+- [x] `GEMINI.md` (Engineering Mandates).
+- [x] `design.md` (System Design & Visuals).
+- [x] `CONTEXT.md` (Ubiquitous Language).
+- [ ] `CONTRIBUTING.md`.
+- [ ] `.github/workflows/ci.yml`.
+- [ ] Automated Benchmarking Suite.
+- [ ] Comprehensive Integration Tests.

--- a/docs/project/design.md
+++ b/docs/project/design.md
@@ -1,0 +1,61 @@
+# Aura: System Design
+
+This document details the visual and architectural design for the `Aura` personas: CLI, TUI, and Headless/Web.
+
+## 🎭 The Three Personas
+
+### 1. The Sprinter (CLI)
+- **Goal**: High-speed, one-off downloads.
+- **Visuals**: Minimalist. Single progress bar per file, total speed summary.
+- **Workflow**: `Aura-cli <URI>`.
+
+### 2. The Pilot (TUI)
+- **Framework**: Ratatui.
+- **Layout**:
+    - **Header**: Global throughput (Up/Down), Active tasks count, NAT status.
+    - **Main Area**: Scrollable list of tasks with interactive selection.
+    - **Sidebar/Panel**: Detailed metadata for selected task (Mirrors, Peer map, Bitfield visualization).
+    - **Footer**: Keybindings (a: add, p: pause, r: resume, d: delete, q: quit).
+- **Theming**: CSS-like theme provider in `Aura.toml`. Supports ANSI 256 colors and Unicode symbols (e.g., Block characters for bitfields).
+- **Remote Mode**: Can "Attach" to a remote `Aura-daemon`.
+
+### 3. The Ghost (Headless / Web)
+- **Goal**: Persistent service for Docker, NAS, or Seedboxes.
+- **RPC Server**: Built on Axum/Tokio.
+    - **Protocol**: JSON-RPC 2.0 and WebSockets.
+    - **Compatibility**: Standardized to allow existing `aria2` frontends (like **AriaNg**) to connect with minimal adaptation.
+- **Docker Design**: Multi-stage build providing a slim alpine/distroless image.
+
+## 🧠 Core Engine Components
+
+### Buffer Pool & Storage
+- **Memory**: Centralized `Bytes` pool with pre-allocated chunks.
+- **Writing**: **Sequential Aggregator** reorders random pieces into contiguous disk flushes.
+- **Safety**: **Atomic Completion** (.part files) ensures no partial files are exposed.
+
+### Connectivity
+- **Happy Eyeballs**: Parallel IPv4/IPv6 racing.
+- **Privacy DNS**: Built-in DoH support to bypass ISP censorship.
+- **NAT Traversal**: Automatic UPnP/NAT-PMP mapping.
+
+## 🏗️ Core Engineering Mandates
+- **Actor Integrity**: Strict decoupling via type-safe channels.
+- **TDD First**: Every component must be developed using Red-Green-Refactor.
+- **Zero-Copy**: Optimize for minimal memory movements.
+
+## 🚀 Implementation Roadmap
+
+### Milestone 1: The Atomic Download (Completed ✅)
+- Fundamental Actor skeleton and HTTP single-source download.
+
+### Milestone 2: The "Smart" Buffer (Current)
+- Implementation of the `Storage Engine` with real I/O, `.part` files, and the `Buffer Pool`.
+
+### Milestone 3: The Swarm (BitTorrent)
+- BitTorrent Protocol Worker, DHT/PEX discovery, and Bitfield management.
+
+### Milestone 4: Hyper-Scale (Aggregator)
+- Racing work-stealer, adaptive scaling, and cross-protocol mirror merging.
+
+### Milestone 5: Visuals & Remote
+- Ratatui TUI implementation and Axum RPC Server.


### PR DESCRIPTION
This PR performs a major documentation cleanup and roadmap synchronization.
- Moved all project documentation to docs/project/.
- Updated README.md links.
- Synchronized TASKS.md with a deep audit of all 37 ADRs.
- Created GitHub issues for newly identified gaps (Magnet Links, Public Rust API, Benchmarking).