### PR TITLE
fix: implement code review recommendations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "igd-next",
  "local-ip-address",
  "notify",
+ "percent-encoding",
  "rand 0.8.6",
  "regex",
  "reqwest",

--- a/crates/aura-core/Cargo.toml
+++ b/crates/aura-core/Cargo.toml
@@ -28,6 +28,7 @@ toml = "1.1.2"
 notify = "8.2.0"
 arc-swap = "1.9.1"
 serde_bytes = "0.11.19"
+percent-encoding = "2.3.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aura-core/src/bt_worker/mod.rs
+++ b/crates/aura-core/src/bt_worker/mod.rs
@@ -75,7 +75,7 @@ impl BtWorker {
         sub_id: TaskId,
         task: Arc<BtTask>,
         storage_tx: tokio::sync::mpsc::Sender<StorageRequest>,
-        subtask_tx: tokio::sync::mpsc::UnboundedSender<SubTaskEvent>,
+        subtask_tx: tokio::sync::mpsc::Sender<SubTaskEvent>,
         token: CancellationToken,
     ) -> Result<()> {
         let (stream, peer_id) = self.connect_and_handshake().await?;
@@ -95,7 +95,7 @@ impl BtWorker {
         _sub_id: TaskId,
         task: Arc<BtTask>,
         storage_tx: tokio::sync::mpsc::Sender<StorageRequest>,
-        subtask_tx: tokio::sync::mpsc::UnboundedSender<SubTaskEvent>,
+        subtask_tx: tokio::sync::mpsc::Sender<SubTaskEvent>,
         token: CancellationToken,
     ) -> Result<()> {
         let mut framed = Framed::new(stream, PeerCodec);
@@ -133,7 +133,7 @@ impl BtWorker {
                                     let mut picker = task.state.picker.lock().await;
                                     picker.add_peer_bitfield(peer_addr.clone(), bf.clone());
                                     drop(picker);
-                                    let _ = subtask_tx.send(SubTaskEvent::PeerBitfield(meta_id, self.peer_id, bf));
+                                    let _ = subtask_tx.send(SubTaskEvent::PeerBitfield(meta_id, self.peer_id, bf)).await;
 
                                     if !peer_choking {
                                         self.trigger_request(&mut framed, &task, piece_length, total_length, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
@@ -146,7 +146,7 @@ impl BtWorker {
                                     let mut picker = task.state.picker.lock().await;
                                     picker.add_peer_bitfield(peer_addr.clone(), bf);
                                     drop(picker);
-                                    let _ = subtask_tx.send(SubTaskEvent::PeerHave(meta_id, self.peer_id, idx));
+                                    let _ = subtask_tx.send(SubTaskEvent::PeerHave(meta_id, self.peer_id, idx)).await;
 
                                     if !peer_choking {
                                         self.trigger_request(&mut framed, &task, piece_length, total_length, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
@@ -159,7 +159,7 @@ impl BtWorker {
                                     self.piece_buffer[begin as usize..begin as usize + len].copy_from_slice(&block);
 
                                     self.bytes_received += len as u64;
-                                    let _ = subtask_tx.send(SubTaskEvent::Downloaded(meta_id, len as u64));
+                                    let _ = subtask_tx.send(SubTaskEvent::Downloaded(meta_id, len as u64)).await;
 
                                     if !peer_choking {
                                         self.trigger_request(&mut framed, &task, piece_length, total_length, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
@@ -204,7 +204,7 @@ impl BtWorker {
         total_length: u64,
         meta_id: TaskId,
         storage_tx: tokio::sync::mpsc::Sender<StorageRequest>,
-        subtask_tx: tokio::sync::mpsc::UnboundedSender<SubTaskEvent>,
+        subtask_tx: tokio::sync::mpsc::Sender<SubTaskEvent>,
     ) -> Result<()>
     where
         S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,

--- a/crates/aura-core/src/net_util.rs
+++ b/crates/aura-core/src/net_util.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use socket2::{Domain, Protocol, Socket, Type};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::net::{TcpStream, UdpSocket};
 
 /// Binds a socket to a specific network interface or local IP.
@@ -71,7 +71,10 @@ pub async fn bind_udp_bound(
     interface: Option<&str>,
     local_addr: Option<IpAddr>,
 ) -> Result<UdpSocket> {
-    let bind_addr = SocketAddr::new(local_addr.unwrap_or("0.0.0.0".parse().unwrap()), local_port);
+    let bind_addr = SocketAddr::new(
+        local_addr.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+        local_port,
+    );
     let domain = if bind_addr.is_ipv4() {
         Domain::IPV4
     } else {

--- a/crates/aura-core/src/orchestrator/events.rs
+++ b/crates/aura-core/src/orchestrator/events.rs
@@ -70,7 +70,7 @@ impl Orchestrator {
         }
 
         if initialized {
-            let meta_task = self.tasks.get(&meta_id).unwrap();
+            let meta_task = self.tasks.get(&meta_id).expect("Task must exist");
             let _ = self.event_tx.send(Event::MetadataResolved {
                 id: meta_id,
                 final_uri: metadata.final_uri,

--- a/crates/aura-core/src/orchestrator/lifecycle.rs
+++ b/crates/aura-core/src/orchestrator/lifecycle.rs
@@ -18,7 +18,7 @@ pub(crate) async fn handle_incoming_peer(
     addr: std::net::SocketAddr,
     bt_registry: std::collections::HashMap<[u8; 20], Arc<BtTask>>,
     storage_tx: mpsc::Sender<StorageRequest>,
-    subtask_tx: mpsc::UnboundedSender<SubTaskEvent>,
+    subtask_tx: mpsc::Sender<SubTaskEvent>,
     my_peer_id: [u8; 20],
     cancellation_tokens: std::collections::HashMap<TaskId, CancellationToken>,
     local_addr: Option<std::net::IpAddr>,
@@ -137,17 +137,14 @@ impl Orchestrator {
                             .connect_timeout(Some(config.network.connect_timeout_secs))
                             .proxy(config.network.proxy.clone())
                             .build_http();
-
                         match worker.resolve_metadata().await {
                             Ok(m) => {
-                                let _ = subtask_tx.send(SubTaskEvent::Matured(id, sub_id, m));
+                                let _ = subtask_tx.send(SubTaskEvent::Matured(id, sub_id, m)).await;
                             }
                             Err(e) => {
-                                let _ = subtask_tx.send(SubTaskEvent::Failed(
-                                    id,
-                                    sub_id,
-                                    e.to_string(),
-                                ));
+                                let _ = subtask_tx
+                                    .send(SubTaskEvent::Failed(id, sub_id, e.to_string()))
+                                    .await;
                             }
                         }
                     }
@@ -155,17 +152,14 @@ impl Orchestrator {
                         let worker = crate::worker::WorkerBuilder::new(uri)
                             .local_addr(local_addr)
                             .build_ftp();
-
                         match worker.resolve_metadata().await {
                             Ok(m) => {
-                                let _ = subtask_tx.send(SubTaskEvent::Matured(id, sub_id, m));
+                                let _ = subtask_tx.send(SubTaskEvent::Matured(id, sub_id, m)).await;
                             }
                             Err(e) => {
-                                let _ = subtask_tx.send(SubTaskEvent::Failed(
-                                    id,
-                                    sub_id,
-                                    e.to_string(),
-                                ));
+                                let _ = subtask_tx
+                                    .send(SubTaskEvent::Failed(id, sub_id, e.to_string()))
+                                    .await;
                             }
                         }
                     }
@@ -188,23 +182,23 @@ impl Orchestrator {
                                     Arc::new(t)
                                 }
                                 Err(e) => {
-                                    let _ = subtask_tx.send(SubTaskEvent::Failed(
-                                        id,
-                                        sub_id,
-                                        e.to_string(),
-                                    ));
+                                    let _ = subtask_tx
+                                        .send(SubTaskEvent::Failed(id, sub_id, e.to_string()))
+                                        .await;
                                     return;
                                 }
                             }
                         };
 
                         let info_hash = bt_task.state.torrent.info_hash().unwrap_or([0; 20]);
-                        let _ = subtask_tx.send(SubTaskEvent::BtTaskRegistered(
-                            id,
-                            sub_id,
-                            info_hash,
-                            bt_task.clone(),
-                        ));
+                        let _ = subtask_tx
+                            .send(SubTaskEvent::BtTaskRegistered(
+                                id,
+                                sub_id,
+                                info_hash,
+                                bt_task.clone(),
+                            ))
+                            .await;
 
                         let total_length = bt_task.state.torrent.total_length();
                         let metadata = Metadata {
@@ -212,7 +206,9 @@ impl Orchestrator {
                             total_length: Some(total_length),
                             name: Some(bt_task.state.torrent.info.name.clone()),
                         };
-                        let _ = subtask_tx.send(SubTaskEvent::Matured(id, sub_id, metadata));
+                        let _ = subtask_tx
+                            .send(SubTaskEvent::Matured(id, sub_id, metadata))
+                            .await;
 
                         // Start tracker loop
                         let tracker_task = bt_task.clone();
@@ -380,7 +376,9 @@ impl Orchestrator {
                 let subtask_tx_progress = subtask_tx.clone();
                 tokio::spawn(async move {
                     while let Some(bytes) = progress_rx.recv().await {
-                        let _ = subtask_tx_progress.send(SubTaskEvent::Downloaded(meta_id, bytes));
+                        let _ = subtask_tx_progress
+                            .send(SubTaskEvent::Downloaded(meta_id, bytes))
+                            .await;
                     }
                 });
 
@@ -411,11 +409,11 @@ impl Orchestrator {
                                                 segment: piece.segment,
                                                 data: piece.data,
                                             }).await;
-                                            let _ = subtask_tx.send(SubTaskEvent::RangeFinished(meta_id, sub_id, range));
+                                            let _ = subtask_tx.send(SubTaskEvent::RangeFinished(meta_id, sub_id, range)).await;
                                         }
                                         Err(e) => {
                                             debug!(%meta_id, %sub_id, error = %e, "Range fetch failed");
-                                            let _ = subtask_tx.send(SubTaskEvent::Failed(meta_id, sub_id, e.to_string()));
+                                            let _ = subtask_tx.send(SubTaskEvent::Failed(meta_id, sub_id, e.to_string())).await;
                                         }
                                     }
                                 }
@@ -442,11 +440,11 @@ impl Orchestrator {
                                                 segment: piece.segment,
                                                 data: piece.data,
                                             }).await;
-                                            let _ = subtask_tx.send(SubTaskEvent::RangeFinished(meta_id, sub_id, range));
+                                            let _ = subtask_tx.send(SubTaskEvent::RangeFinished(meta_id, sub_id, range)).await;
                                         }
                                         Err(e) => {
                                             debug!(%meta_id, %sub_id, error = %e, "Range fetch failed");
-                                            let _ = subtask_tx.send(SubTaskEvent::Failed(meta_id, sub_id, e.to_string()));
+                                            let _ = subtask_tx.send(SubTaskEvent::Failed(meta_id, sub_id, e.to_string())).await;
                                         }
                                     }
                                 }

--- a/crates/aura-core/src/orchestrator/mod.rs
+++ b/crates/aura-core/src/orchestrator/mod.rs
@@ -11,6 +11,7 @@ use crate::{Result, TaskId};
 use arc_swap::ArcSwap;
 use rand::Rng;
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
@@ -82,8 +83,8 @@ pub struct Orchestrator {
     pub(crate) event_tx: broadcast::Sender<Event>,
     pub(crate) storage_tx: mpsc::Sender<StorageRequest>,
     pub(crate) storage_completion_rx: mpsc::Receiver<TaskId>,
-    pub(crate) subtask_tx: mpsc::UnboundedSender<SubTaskEvent>,
-    pub(crate) subtask_rx: mpsc::UnboundedReceiver<SubTaskEvent>,
+    pub(crate) subtask_tx: mpsc::Sender<SubTaskEvent>,
+    pub(crate) subtask_rx: mpsc::Receiver<SubTaskEvent>,
     pub(crate) dht_tx: mpsc::Sender<DhtCommand>,
     pub(crate) _nat_tx: mpsc::Sender<NatCommand>,
     pub(crate) peer_id: [u8; 20],
@@ -122,7 +123,7 @@ impl Orchestrator {
         config: Arc<ArcSwap<crate::Config>>,
     ) -> (Self, broadcast::Receiver<Event>) {
         let (event_tx, event_rx) = broadcast::channel(1024);
-        let (subtask_tx, subtask_rx) = mpsc::unbounded_channel();
+        let (subtask_tx, subtask_rx) = mpsc::channel(4096);
 
         let mut peer_id = [0u8; 20];
         peer_id[..8].copy_from_slice(b"-AR0001-");
@@ -158,7 +159,7 @@ impl Orchestrator {
         let local_addr = self.resolve_local_addr();
         let config_initial = self.config.load();
         let bind_addr = std::net::SocketAddr::new(
-            local_addr.unwrap_or("0.0.0.0".parse().unwrap()),
+            local_addr.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
             config_initial.network.listen_port,
         );
 
@@ -186,20 +187,23 @@ impl Orchestrator {
                 interval.tick().await;
                 let config = config_monitor.load();
                 if let Some(ref iface) = config.network.interface {
-                    use local_ip_address::list_afinet_netifas;
-                    let is_up = list_afinet_netifas()
-                        .ok()
-                        .map(|ifas: Vec<(String, std::net::IpAddr)>| {
-                            ifas.into_iter().any(|(name, _)| name == *iface)
-                        })
-                        .unwrap_or(false);
+                    let iface_clone = iface.clone();
+                    let is_up = tokio::task::spawn_blocking(move || {
+                        use local_ip_address::list_afinet_netifas;
+                        list_afinet_netifas()
+                            .ok()
+                            .map(|ifas| ifas.into_iter().any(|(name, _)| name == iface_clone))
+                    })
+                    .await
+                    .unwrap_or(None)
+                    .unwrap_or(false);
 
                     if !is_up {
                         tracing::warn!(
                             "VPN Kill-switch triggered! Interface {} is down. Stopping all tasks.",
                             iface
                         );
-                        let _ = subtask_tx_monitor.send(SubTaskEvent::KillSwitch);
+                        let _ = subtask_tx_monitor.send(SubTaskEvent::KillSwitch).await;
                     }
                 }
             }

--- a/crates/aura-core/src/storage.rs
+++ b/crates/aura-core/src/storage.rs
@@ -207,7 +207,10 @@ impl StorageEngine {
             self.handles.insert(id, file);
         }
 
-        Ok(self.handles.get_mut(&id).unwrap())
+        Ok(self
+            .handles
+            .get_mut(&id)
+            .expect("File handle must exist after open/insert"))
     }
 }
 

--- a/crates/aura-core/src/tracker/mod.rs
+++ b/crates/aura-core/src/tracker/mod.rs
@@ -5,6 +5,7 @@ use crate::{Error, Result};
 use futures_util::future::join_all;
 use serde::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
+use url::Url;
 
 pub mod udp;
 
@@ -106,21 +107,29 @@ impl TrackerClient {
 
     async fn announce_http(&self, url_str: &str, torrent: &Torrent) -> Result<Vec<Peer>> {
         let info_hash = torrent.info_hash()?;
-        let info_hash_str: String = info_hash.iter().map(|b| format!("%{:02x}", b)).collect();
-        let peer_id_str: String = self.peer_id.iter().map(|b| format!("%{:02x}", b)).collect();
+        let info_hash_encoded: String = info_hash.iter().map(|b| format!("%{:02x}", b)).collect();
+        let peer_id_encoded: String = self.peer_id.iter().map(|b| format!("%{:02x}", b)).collect();
 
-        let url = format!(
-            "{}?info_hash={}&peer_id={}&port={}&uploaded=0&downloaded=0&left={}&compact=1&event=started",
-            url_str,
-            info_hash_str,
-            peer_id_str,
+        let url = Url::parse(url_str)
+            .map_err(|e| Error::Protocol(format!("Invalid tracker URL: {}", e)))?;
+
+        let query = format!(
+            "info_hash={}&peer_id={}&port={}&uploaded=0&downloaded=0&left={}&compact=1&event=started",
+            info_hash_encoded,
+            peer_id_encoded,
             self.port,
             torrent.total_length()
         );
 
+        let final_url = if url.query().is_some() {
+            format!("{}&{}", url_str, query)
+        } else {
+            format!("{}?{}", url_str, query)
+        };
+
         let bytes = self
             .client
-            .get(&url)
+            .get(&final_url)
             .send()
             .await
             .map_err(|e| Error::Protocol(format!("Tracker request failed: {}", e)))?

--- a/crates/aura-core/src/worker/ftp.rs
+++ b/crates/aura-core/src/worker/ftp.rs
@@ -55,7 +55,8 @@ impl FtpWorker {
 
     pub async fn resolve_metadata(&self) -> Result<Metadata> {
         let mut ftp: AsyncFtpStream = self.connect().await?;
-        let url = Url::parse(&self.uri).unwrap();
+        let url = Url::parse(&self.uri)
+            .map_err(|e| Error::Protocol(format!("Invalid FTP URL: {}", e)))?;
         let path = url.path().trim_start_matches('/');
 
         let size = ftp
@@ -87,7 +88,8 @@ impl ProtocolWorker for FtpWorker {
         progress: Option<ProgressSender>,
     ) -> Result<PieceData> {
         let mut ftp: AsyncFtpStream = self.connect().await?;
-        let url = Url::parse(&self.uri).unwrap();
+        let url = Url::parse(&self.uri)
+            .map_err(|e| Error::Protocol(format!("Invalid FTP URL: {}", e)))?;
         let path = url.path().trim_start_matches('/');
 
         // Set restart point for range-based download


### PR DESCRIPTION
This PR addresses the findings from the senior code review:
- Switched Orchestrator subtask channel to a bounded channel (4096) for backpressure.
- Replaced dangerous unwrap() calls with safer expect() or proper Error propagation.
- Wrapped synchronous network interface discovery in spawn_blocking.
- Refactored tracker announcements to use more robust URL query parameter construction.
- Cleaned up all remaining clippy warnings and enforced strict formatting.