### PR TITLE
feat: BitTorrent Endgame Mode

### DIFF
--- a/crates/aura-core/src/bt_worker/mod.rs
+++ b/crates/aura-core/src/bt_worker/mod.rs
@@ -1,5 +1,5 @@
 use crate::bt_task::BtTask;
-use crate::orchestrator::SubTaskEvent;
+use crate::orchestrator::{SubTaskEvent, WorkerCommand};
 use crate::storage::StorageRequest;
 use crate::{Error, Result, TaskId};
 use bytes::BytesMut;
@@ -80,6 +80,7 @@ impl BtWorker {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_loop(
         mut self,
         _meta_id: TaskId,
@@ -87,6 +88,7 @@ impl BtWorker {
         task: Arc<BtTask>,
         storage_tx: tokio::sync::mpsc::Sender<StorageRequest>,
         subtask_tx: tokio::sync::mpsc::Sender<SubTaskEvent>,
+        command_rx: tokio::sync::broadcast::Receiver<WorkerCommand>,
         token: CancellationToken,
     ) -> Result<()> {
         let (stream, peer_id, ext_support) = self.connect_and_handshake().await?;
@@ -99,6 +101,7 @@ impl BtWorker {
             task,
             storage_tx,
             subtask_tx,
+            command_rx,
             token,
             ext_support,
         )
@@ -114,11 +117,12 @@ impl BtWorker {
         task: Arc<BtTask>,
         storage_tx: tokio::sync::mpsc::Sender<StorageRequest>,
         subtask_tx: tokio::sync::mpsc::Sender<SubTaskEvent>,
+        command_rx: tokio::sync::broadcast::Receiver<WorkerCommand>,
         token: CancellationToken,
     ) -> Result<()> {
         // Default to no extension support if not specified (legacy path)
         self.run_loop_with_stream_and_ext(
-            stream, meta_id, sub_id, task, storage_tx, subtask_tx, token, false,
+            stream, meta_id, sub_id, task, storage_tx, subtask_tx, command_rx, token, false,
         )
         .await
     }
@@ -132,6 +136,7 @@ impl BtWorker {
         task: Arc<BtTask>,
         storage_tx: tokio::sync::mpsc::Sender<StorageRequest>,
         subtask_tx: tokio::sync::mpsc::Sender<SubTaskEvent>,
+        mut command_rx: tokio::sync::broadcast::Receiver<WorkerCommand>,
         token: CancellationToken,
         ext_support: bool,
     ) -> Result<()> {
@@ -165,6 +170,23 @@ impl BtWorker {
         loop {
             tokio::select! {
                 _ = token.cancelled() => break,
+                Ok(cmd) = command_rx.recv() => {
+                    match cmd {
+                        WorkerCommand::CancelPiece(piece_idx) => {
+                            if Some(piece_idx) == self.current_piece {
+                                debug!(addr = %peer_addr, %piece_idx, "Received cancellation for current piece");
+                                // We don't need to send CANCEL to peer necessarily if we just ignore the blocks,
+                                // but we should stop requesting.
+                                self.current_piece = None;
+                                self.bytes_received = 0;
+                                self.bytes_requested = 0;
+                                self.piece_buffer.clear();
+                                // Try to pick a new piece
+                                self.trigger_request(&mut framed, &task, meta_id, sub_id, storage_tx.clone(), subtask_tx.clone()).await?;
+                            }
+                        }
+                    }
+                }
                 msg_res = framed.next() => {
                     match msg_res {
                         Some(Ok(msg)) => {
@@ -175,7 +197,7 @@ impl BtWorker {
                                 PeerMessage::Unchoke => {
                                     peer_choking = false;
                                     debug!(addr = %peer_addr, "Peer unchoked us");
-                                    self.trigger_request(&mut framed, &task, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
+                                    self.trigger_request(&mut framed, &task, meta_id, sub_id, storage_tx.clone(), subtask_tx.clone()).await?;
                                 }
                                 PeerMessage::Bitfield(bits) => {
                                     let bf = crate::bitfield::Bitfield::from_bytes(&bits, task.state.torrent.lock().await.as_ref().map(|t| t.pieces_count()).unwrap_or(0));
@@ -189,7 +211,7 @@ impl BtWorker {
                                     let _ = subtask_tx.send(SubTaskEvent::PeerBitfield(meta_id, self.peer_id, bf)).await;
 
                                     if !peer_choking {
-                                        self.trigger_request(&mut framed, &task, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
+                                        self.trigger_request(&mut framed, &task, meta_id, sub_id, storage_tx.clone(), subtask_tx.clone()).await?;
                                     }
                                 }
                                 PeerMessage::Have(idx) => {
@@ -204,7 +226,7 @@ impl BtWorker {
                                     let _ = subtask_tx.send(SubTaskEvent::PeerHave(meta_id, self.peer_id, idx)).await;
 
                                     if !peer_choking {
-                                        self.trigger_request(&mut framed, &task, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
+                                        self.trigger_request(&mut framed, &task, meta_id, sub_id, storage_tx.clone(), subtask_tx.clone()).await?;
                                     }
                                 }
                                 PeerMessage::Extended { id, payload } => {
@@ -216,7 +238,7 @@ impl BtWorker {
                                                 if let (Some(size), Some(_)) = (hs.metadata_size, self.ut_metadata_id) {
                                                     info!(%peer_addr, %size, "Metadata size discovered from peer");
                                                     self.metadata_buffer = Some(BytesMut::zeroed(size));
-                                                    self.trigger_request(&mut framed, &task, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
+                                                    self.trigger_request(&mut framed, &task, meta_id, sub_id, storage_tx.clone(), subtask_tx.clone()).await?;
                                                 }
                                             }
                                         }
@@ -248,7 +270,7 @@ impl BtWorker {
                                                                     info!(%peer_addr, "Metadata successfully received and verified");
                                                                     let _ = subtask_tx.send(SubTaskEvent::MetadataReceived(meta_id, sub_id, torrent)).await;
                                                                     // After metadata, we might transition to piece picking
-                                                                    self.trigger_request(&mut framed, &task, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
+                                                                    self.trigger_request(&mut framed, &task, meta_id, sub_id, storage_tx.clone(), subtask_tx.clone()).await?;
                                                                 } else {
                                                                     warn!(%peer_addr, "Received metadata hash mismatch!");
                                                                 }
@@ -270,7 +292,7 @@ impl BtWorker {
                                     let _ = subtask_tx.send(SubTaskEvent::Downloaded(meta_id, len as u64)).await;
 
                                     if !peer_choking {
-                                        self.trigger_request(&mut framed, &task, meta_id, storage_tx.clone(), subtask_tx.clone()).await?;
+                                        self.trigger_request(&mut framed, &task, meta_id, sub_id, storage_tx.clone(), subtask_tx.clone()).await?;
                                     }
                                 }
                                 _ => {}
@@ -291,6 +313,7 @@ impl BtWorker {
         framed: &mut Framed<S, PeerCodec>,
         task: &BtTask,
         meta_id: TaskId,
+        sub_id: TaskId,
         storage_tx: tokio::sync::mpsc::Sender<StorageRequest>,
         subtask_tx: tokio::sync::mpsc::Sender<SubTaskEvent>,
     ) -> Result<()>
@@ -315,6 +338,28 @@ impl BtWorker {
                     .await?;
             }
             return Ok(());
+        }
+
+        // 2. Check if current piece was finished by someone else
+        if let Some(piece_idx) = self.current_piece {
+            let finished = {
+                let bf_guard = task.state.bitfield.lock().await;
+                bf_guard
+                    .as_ref()
+                    .map(|bf| bf.get(piece_idx))
+                    .unwrap_or(false)
+            };
+            if finished {
+                debug!(addr = %self.peer_addr, %piece_idx, "Piece finished by another worker, dropping");
+                self.current_piece = None;
+                self.bytes_received = 0;
+                self.bytes_requested = 0;
+                self.piece_buffer.clear();
+                return Box::pin(
+                    self.trigger_request(framed, task, meta_id, sub_id, storage_tx, subtask_tx),
+                )
+                .await;
+            }
         }
 
         let torrent_guard = task.state.torrent.lock().await;
@@ -360,6 +405,11 @@ impl BtWorker {
                     if let Some(ref mut picker) = *picker_guard {
                         picker.mark_completed(piece_idx);
                     }
+                    drop(picker_guard);
+
+                    let _ = subtask_tx
+                        .send(SubTaskEvent::PieceVerified(meta_id, sub_id, piece_idx))
+                        .await;
                 } else {
                     error!(addr = %self.peer_addr, %piece_idx, "Piece hash mismatch!");
                     let mut picker_guard = task.state.picker.lock().await;
@@ -375,7 +425,7 @@ impl BtWorker {
 
                 drop(torrent_guard);
                 return Box::pin(
-                    self.trigger_request(framed, task, meta_id, storage_tx, subtask_tx),
+                    self.trigger_request(framed, task, meta_id, sub_id, storage_tx, subtask_tx),
                 )
                 .await;
             }
@@ -420,7 +470,7 @@ impl BtWorker {
                     drop(bf_guard);
                     drop(torrent_guard);
                     return Box::pin(
-                        self.trigger_request(framed, task, meta_id, storage_tx, subtask_tx),
+                        self.trigger_request(framed, task, meta_id, sub_id, storage_tx, subtask_tx),
                     )
                     .await;
                 }

--- a/crates/aura-core/src/orchestrator/events.rs
+++ b/crates/aura-core/src/orchestrator/events.rs
@@ -1,4 +1,4 @@
-use super::{Event, Orchestrator, SubTaskEvent};
+use super::{Event, Orchestrator, SubTaskEvent, WorkerCommand};
 use crate::task::DownloadPhase;
 use crate::{Result, TaskId};
 use tracing::{debug, info};
@@ -37,9 +37,16 @@ impl Orchestrator {
             SubTaskEvent::PeerHave(meta_id, peer_id, idx) => {
                 debug!(%meta_id, ?peer_id, idx, "Peer reported piece availability");
             }
-            SubTaskEvent::BtTaskRegistered(_meta_id, sub_id, info_hash, task) => {
+            SubTaskEvent::PieceVerified(meta_id, sub_id, piece_idx) => {
+                debug!(%meta_id, %sub_id, piece_idx, "Broadcasting cancellation for verified piece");
+                if let Some(tx) = self.worker_command_txs.get(&sub_id) {
+                    let _ = tx.send(WorkerCommand::CancelPiece(piece_idx));
+                }
+            }
+            SubTaskEvent::BtTaskRegistered(_meta_id, sub_id, info_hash, task, worker_cmd_tx) => {
                 self.bt_registry.insert(info_hash, task.clone());
                 self.bt_tasks.insert(sub_id, task);
+                self.worker_command_txs.insert(sub_id, worker_cmd_tx);
             }
             SubTaskEvent::KillSwitch => {
                 let ids: Vec<TaskId> = self.tasks.keys().cloned().collect();

--- a/crates/aura-core/src/orchestrator/lifecycle.rs
+++ b/crates/aura-core/src/orchestrator/lifecycle.rs
@@ -1,4 +1,4 @@
-use super::{Orchestrator, SubTaskEvent};
+use super::{Orchestrator, SubTaskEvent, WorkerCommand};
 use crate::bitfield::Bitfield;
 use crate::bt_task::BtTask;
 use crate::bt_worker::BtWorker;
@@ -17,6 +17,10 @@ pub(crate) async fn handle_incoming_peer(
     mut stream: TcpStream,
     addr: std::net::SocketAddr,
     bt_registry: std::collections::HashMap<[u8; 20], Arc<BtTask>>,
+    worker_command_txs: std::collections::HashMap<
+        TaskId,
+        tokio::sync::broadcast::Sender<WorkerCommand>,
+    >,
     storage_tx: mpsc::Sender<StorageRequest>,
     subtask_tx: mpsc::Sender<SubTaskEvent>,
     my_peer_id: [u8; 20],
@@ -51,6 +55,17 @@ pub(crate) async fn handle_incoming_peer(
             );
             worker.local_addr = local_addr;
             worker.pipeline_size = config.bittorrent.request_pipeline_size;
+
+            // SubId in bt_tasks/worker_command_txs is task.id for simple single-torrent tasks
+            // In more complex ones it might be different, but for now we use task.id
+            let w_cmd_rx = if let Some(tx) = worker_command_txs.get(&task.id) {
+                tx.subscribe()
+            } else {
+                // Fallback to a dummy channel if not found (shouldn't happen for valid tasks)
+                let (dummy_tx, _) = tokio::sync::broadcast::channel::<WorkerCommand>(1);
+                dummy_tx.subscribe()
+            };
+
             worker
                 .run_loop_with_stream(
                     stream,
@@ -59,6 +74,7 @@ pub(crate) async fn handle_incoming_peer(
                     task.clone(),
                     storage_tx,
                     subtask_tx,
+                    w_cmd_rx,
                     token.clone(),
                 )
                 .await
@@ -202,6 +218,8 @@ impl Orchestrator {
                             }
                         };
 
+                        let (worker_cmd_tx, _) = tokio::sync::broadcast::channel(1024);
+
                         let info_hash = bt_task.state.info_hash;
                         let _ = subtask_tx
                             .send(SubTaskEvent::BtTaskRegistered(
@@ -209,6 +227,7 @@ impl Orchestrator {
                                 sub_id,
                                 info_hash,
                                 bt_task.clone(),
+                                worker_cmd_tx.clone(),
                             ))
                             .await;
 
@@ -306,6 +325,7 @@ impl Orchestrator {
                                         let peer_task_inner = peer_task.clone();
                                         let active_counter = active_workers.clone();
                                         let t4 = t3.clone();
+                                        let w_cmd_rx = worker_cmd_tx.subscribe();
 
                                         active_counter.fetch_add(1, Ordering::Relaxed);
                                         tokio::spawn(async move {
@@ -316,6 +336,7 @@ impl Orchestrator {
                                                     peer_task_inner,
                                                     s_tx,
                                                     sub_tx,
+                                                    w_cmd_rx,
                                                     t4,
                                                 )
                                                 .await

--- a/crates/aura-core/src/orchestrator/mod.rs
+++ b/crates/aura-core/src/orchestrator/mod.rs
@@ -41,6 +41,11 @@ pub enum Command {
     Shutdown,
 }
 
+#[derive(Debug, Clone)]
+pub enum WorkerCommand {
+    CancelPiece(usize),
+}
+
 #[derive(Debug)]
 pub enum SubTaskEvent {
     Matured(TaskId, TaskId, Metadata),
@@ -50,7 +55,14 @@ pub enum SubTaskEvent {
     Downloaded(TaskId, u64),
     PeerBitfield(TaskId, PeerId, Bitfield),
     PeerHave(TaskId, PeerId, u32),
-    BtTaskRegistered(TaskId, TaskId, [u8; 20], Arc<BtTask>),
+    PieceVerified(TaskId, TaskId, usize),
+    BtTaskRegistered(
+        TaskId,
+        TaskId,
+        [u8; 20],
+        Arc<BtTask>,
+        tokio::sync::broadcast::Sender<WorkerCommand>,
+    ),
     KillSwitch,
 }
 
@@ -80,6 +92,7 @@ pub struct Orchestrator {
     pub(crate) tasks: HashMap<TaskId, MetaTask>,
     pub(crate) bt_registry: HashMap<[u8; 20], Arc<BtTask>>,
     pub(crate) bt_tasks: HashMap<TaskId, Arc<BtTask>>, // Key: sub_id
+    pub(crate) worker_command_txs: HashMap<TaskId, tokio::sync::broadcast::Sender<WorkerCommand>>, // Key: sub_id
     pub(crate) cancellation_tokens: HashMap<TaskId, CancellationToken>,
     pub(crate) command_rx: mpsc::Receiver<Command>,
     pub(crate) event_tx: broadcast::Sender<Event>,
@@ -138,6 +151,7 @@ impl Orchestrator {
                 tasks: HashMap::new(),
                 bt_registry: HashMap::new(),
                 bt_tasks: HashMap::new(),
+                worker_command_txs: HashMap::new(),
                 cancellation_tokens: HashMap::new(),
                 command_rx,
                 event_tx,
@@ -221,6 +235,7 @@ impl Orchestrator {
                 }
                 Ok((stream, addr)) = listener.accept() => {
                     let bt_registry = self.bt_registry.clone();
+                    let worker_command_txs = self.worker_command_txs.clone();
                     let storage_tx = self.storage_tx.clone();
                     let subtask_tx = self.subtask_tx.clone();
                     let my_peer_id = self.peer_id;
@@ -229,7 +244,7 @@ impl Orchestrator {
                     let config = self.config.load().clone();
 
                     tokio::spawn(async move {
-                        if let Err(e) = lifecycle::handle_incoming_peer(stream, addr, bt_registry, storage_tx, subtask_tx, my_peer_id, cancellation_tokens, local_addr, config).await {
+                        if let Err(e) = lifecycle::handle_incoming_peer(stream, addr, bt_registry, worker_command_txs, storage_tx, subtask_tx, my_peer_id, cancellation_tokens, local_addr, config).await {
                             tracing::debug!(?addr, error = %e, "Failed to handle incoming peer");
                         }
                     });

--- a/crates/aura-core/src/piece_picker.rs
+++ b/crates/aura-core/src/piece_picker.rs
@@ -75,6 +75,10 @@ impl PiecePicker {
     /// Picks the next piece to download using the rarest-first strategy,
     /// considering only pieces that the specified peer has.
     pub fn pick_next(&self, my_bitfield: &Bitfield, peer_addr: &str) -> Option<usize> {
+        if self.is_endgame(my_bitfield) {
+            return self.pick_next_endgame(my_bitfield, peer_addr);
+        }
+
         let peer_bf = self.peer_bitfields.get(peer_addr)?;
 
         let mut rarest_pieces = Vec::new();
@@ -104,6 +108,31 @@ impl PiecePicker {
             rarest_pieces.choose(&mut rand::thread_rng()).copied()
         }
     }
+
+    /// Determines if the task is in "Endgame Mode".
+    pub fn is_endgame(&self, my_bitfield: &Bitfield) -> bool {
+        let remaining = self.num_pieces - my_bitfield.count_set();
+        // Endgame triggers when very few pieces are left (e.g., < 3 or < 1%)
+        if remaining == 0 {
+            return false;
+        }
+        remaining <= 3 || (remaining as f32 / self.num_pieces as f32) < 0.01
+    }
+
+    /// Picks a piece even if it's already in progress (redundant fetching).
+    pub fn pick_next_endgame(&self, my_bitfield: &Bitfield, peer_addr: &str) -> Option<usize> {
+        let peer_bf = self.peer_bitfields.get(peer_addr)?;
+
+        let mut available = Vec::new();
+        for i in 0..self.num_pieces {
+            if !my_bitfield.get(i) && peer_bf.get(i) {
+                available.push(i);
+            }
+        }
+
+        use rand::seq::SliceRandom;
+        available.choose(&mut rand::thread_rng()).copied()
+    }
 }
 
 #[cfg(test)]
@@ -112,18 +141,18 @@ mod tests {
 
     #[test]
     fn test_rarest_first_selection() {
-        let mut picker = PiecePicker::new(5);
-        let my_bf = Bitfield::new(5);
+        let mut picker = PiecePicker::new(10);
+        let my_bf = Bitfield::new(10);
 
         // Peer A has pieces 0, 1, 2
-        let mut bf_a = Bitfield::new(5);
+        let mut bf_a = Bitfield::new(10);
         bf_a.set(0, true);
         bf_a.set(1, true);
         bf_a.set(2, true);
         picker.add_peer_bitfield("1.1.1.1:80".to_string(), bf_a);
 
         // Peer B has pieces 0, 3
-        let mut bf_b = Bitfield::new(5);
+        let mut bf_b = Bitfield::new(10);
         bf_b.set(0, true);
         bf_b.set(3, true);
         picker.add_peer_bitfield("2.2.2.2:80".to_string(), bf_b);
@@ -149,5 +178,27 @@ mod tests {
             .pick_next(&my_bf_updated, "1.1.1.1:80")
             .expect("Should pick another piece");
         assert_eq!(picked2, 2);
+    }
+
+    #[test]
+    fn test_endgame_mode_trigger() {
+        let mut picker = PiecePicker::new(2);
+        let my_bf = Bitfield::new(2);
+        let mut peer_bf = Bitfield::new(2);
+        peer_bf.set(0, true);
+        peer_bf.set(1, true);
+        picker.add_peer_bitfield("peer1".to_string(), peer_bf);
+
+        // Mark all pieces as in progress
+        picker.mark_in_progress(0);
+        picker.mark_in_progress(1);
+
+        // Standard pick SHOULD now return a piece because we are in endgame (2/2 pieces)
+        let picked = picker.pick_next(&my_bf, "peer1");
+        assert!(picked.is_some());
+
+        // Also verify explicitly calling pick_next_endgame
+        let picked_explicit = picker.pick_next_endgame(&my_bf, "peer1");
+        assert!(picked_explicit.is_some());
     }
 }

--- a/docs/adr/0039-bittorrent-endgame-mode.md
+++ b/docs/adr/0039-bittorrent-endgame-mode.md
@@ -1,0 +1,34 @@
+# ADR 0039: BitTorrent Endgame Mode
+
+## Status
+Proposed
+
+## Context
+In a BitTorrent swarm, the final blocks of a download often take much longer to retrieve than the rest. This happens because some peers might be slow, or their connection might drop after we've requested a piece but before it's delivered. This is known as the "99% stall."
+
+## Decision
+We will implement "Endgame Mode." When a download is nearly complete and all remaining pieces have been requested at least once, the system will enter a specialized state where redundant requests are sent to multiple peers for the same blocks.
+
+### 1. Trigger Condition
+Endgame Mode is triggered when:
+- The number of pending pieces is small (e.g., < 5 pieces or < 2% of total pieces).
+- All pending pieces are already marked as `in_progress` in the `PiecePicker`.
+
+### 2. Piece Picking in Endgame
+In Endgame Mode, `PiecePicker::pick_next` will:
+- Ignore the `in_progress` bitfield.
+- Pick from pieces that the peer has but that we have not yet marked as `completed`.
+- Still prioritize rarest-first if applicable.
+
+### 3. Redundant Requests & Verification
+- `BtWorker` will request blocks for endgame pieces even if they are already being downloaded by other workers.
+- The `StorageEngine` and `PiecePicker` act as the source of truth. When a piece is successfully verified and written to disk, it is marked as `completed`.
+- Workers must check if a piece/block is already completed before sending a request.
+
+### 4. Cancellation (Optional but Recommended)
+When a worker successfully verifies a piece, it should notify the `Orchestrator`. The `Orchestrator` should then send a signal to all other `BtWorkers` downloading that same piece to send `Cancel` messages to their respective peers. This saves swarm bandwidth.
+
+## Consequences
+- **Pros**: Significantly reduces the time to finish downloads. Eliminates the "slowest peer" bottleneck at the end of a task.
+- **Cons**: Slightly increased bandwidth usage due to redundant block downloads (this is acceptable given it only happens at the very end).
+- **Complexity**: Requires careful coordination between workers and the picker to avoid thundering herds.

--- a/docs/project/TASKS.md
+++ b/docs/project/TASKS.md
@@ -31,7 +31,7 @@
 ## ✅ Milestone 4: Hyper-Scale (Aggregator) (Completed)
 - [x] **Sourced Aggregator** (Multi-protocol task merging).
 - [x] **Work Stealing & Racing** (Speculative execution).
-- [ ] **Endgame Mode** (Parallel final block fetching).
+- [x] **Endgame Mode** (Parallel final block fetching).
 - [x] **Adaptive Connection Scaling** (Bypassing per-connection caps).
 - [x] **Hierarchical Throttling** (Global + Per-task speed limits).
 


### PR DESCRIPTION
This PR implements Endgame Mode to address the '99% stall' problem in BitTorrent downloads.
- Updated PiecePicker to detect endgame threshold (< 3 pieces or < 1%).
- Implemented redundant piece picking in Endgame Mode.
- Added a broadcast channel system to coordinate piece cancellations between workers.
- Workers now drop pieces and pick new work as soon as any other peer delivers a verified block.
- Passed full Green Loop verification.