### PR TITLE
feat: implement BitTorrent v2 file alignment and padding (#68)

### DIFF
--- a/crates/aura-core/src/bt_worker/logic.rs
+++ b/crates/aura-core/src/bt_worker/logic.rs
@@ -76,11 +76,9 @@ impl super::BtWorker {
         let max_in_flight = self.pipeline_size as u64 * BLOCK_SIZE as u64;
 
         if let Some(piece_idx) = self.current_piece {
-            let piece_total_len = if piece_idx == torrent.pieces_count() - 1 {
-                total_length - (piece_idx as u64 * piece_length)
-            } else {
-                piece_length
-            };
+            let piece_total_len = torrent
+                .piece_actual_length(piece_idx)
+                .unwrap_or(piece_length);
 
             // Ensure buffer is initialized if it was set via RequestPiece (Endgame)
             if self.piece_buffer.is_empty() {
@@ -127,11 +125,15 @@ impl super::BtWorker {
                     let finished_data =
                         std::mem::replace(&mut self.piece_buffer, self.pool.acquire());
 
+                    let offset = torrent
+                        .piece_align_offset(piece_idx)
+                        .unwrap_or(piece_idx as u64 * piece_length);
+
                     let _ = storage_tx
                         .send(StorageRequest::Write {
                             task_id: meta_id,
                             segment: crate::worker::Segment {
-                                offset: piece_idx as u64 * piece_length,
+                                offset,
                                 length: piece_total_len,
                             },
                             data: finished_data,

--- a/crates/aura-core/src/bt_worker/mod.rs
+++ b/crates/aura-core/src/bt_worker/mod.rs
@@ -311,17 +311,13 @@ impl BtWorker {
                                             .send(StorageRequest::Read {
                                                 task_id: meta_id,
                                                 segment: crate::worker::Segment {
-                                                    offset: index as u64
-                                                        * task
-                                                            .state
-                                                            .torrent
-                                                            .lock()
-                                                            .await
-                                                            .as_ref()
-                                                            .unwrap()
-                                                            .info
-                                                            .piece_length
-                                                        + begin as u64,
+                                                    offset: {
+                                                        let torrent_guard = task.state.torrent.lock().await;
+                                                        let torrent = torrent_guard.as_ref().unwrap();
+                                                        let base_offset = torrent.piece_align_offset(index as usize)
+                                                            .unwrap_or(index as u64 * torrent.info.piece_length);
+                                                        base_offset + begin as u64
+                                                    },
                                                     length: length as u64,
                                                 },
                                                 reply_tx,

--- a/crates/aura-core/src/torrent.rs
+++ b/crates/aura-core/src/torrent.rs
@@ -262,6 +262,88 @@ impl Torrent {
             "Piece index out of range for v2".to_string(),
         ))
     }
+
+    pub fn piece_align_offset(&self, index: usize) -> Result<u64> {
+        if self.info.meta_version != Some(2) {
+            return Ok((index as u64) * self.info.piece_length);
+        }
+
+        let piece_len = self.info.piece_length;
+        let files = self
+            .flatten_v2_files()
+            .ok_or_else(|| Error::Protocol("No v2 files found".to_string()))?;
+
+        let mut current_piece_offset = 0;
+        let mut byte_offset = 0;
+
+        for file in files {
+            let file_pieces = if file.length == 0 {
+                0
+            } else {
+                (file.length as usize).div_ceil(piece_len as usize)
+            };
+
+            if index >= current_piece_offset && index < current_piece_offset + file_pieces {
+                let file_piece_idx = index - current_piece_offset;
+                return Ok(byte_offset + (file_piece_idx as u64 * piece_len));
+            }
+
+            current_piece_offset += file_pieces;
+            byte_offset += (file_pieces as u64) * piece_len;
+        }
+
+        Err(Error::Protocol(
+            "Piece index out of range for v2 alignment".to_string(),
+        ))
+    }
+
+    pub fn piece_actual_length(&self, index: usize) -> Result<u64> {
+        let piece_len = self.info.piece_length;
+
+        if self.info.meta_version != Some(2) {
+            let total = self.total_length();
+            let piece_start = index as u64 * piece_len;
+            if piece_start >= total {
+                return Err(Error::Protocol("Piece index out of range".to_string()));
+            }
+            return Ok(std::cmp::min(piece_len, total - piece_start));
+        }
+
+        let files = self
+            .flatten_v2_files()
+            .ok_or_else(|| Error::Protocol("No v2 files found".to_string()))?;
+
+        let mut current_piece_offset = 0;
+        for file in files {
+            let file_pieces = if file.length == 0 {
+                0
+            } else {
+                (file.length as usize).div_ceil(piece_len as usize)
+            };
+
+            if index >= current_piece_offset && index < current_piece_offset + file_pieces {
+                let file_piece_idx = index - current_piece_offset;
+
+                // If it's the last piece of the file, its actual length might be smaller
+                if file_piece_idx == file_pieces - 1 {
+                    let remainder = file.length % piece_len;
+                    if remainder == 0 {
+                        return Ok(piece_len);
+                    } else {
+                        return Ok(remainder);
+                    }
+                } else {
+                    return Ok(piece_len);
+                }
+            }
+
+            current_piece_offset += file_pieces;
+        }
+
+        Err(Error::Protocol(
+            "Piece index out of range for v2".to_string(),
+        ))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR implements **Phase 4** of the BitTorrent v2 upgrade, adding support for BEP 52 file alignment and implicit padding.

### 🛠️ Implementation Details
- **Piece Offset Translation**: Added `piece_align_offset` to `Torrent`. This translates a global piece index into its true byte offset within the physical downloaded file, handling the "padded gaps" at the end of unaligned files.
- **Actual Length Calculation**: Added `piece_actual_length` to calculate the real byte length of a piece over the wire. This ensures workers do not request the "padding" at the end of files from peers.
- **Worker/Storage Integration**: Updated `BtWorker`'s read and write handlers to map the requested and received pieces through these alignment functions. The `StorageEngine` now receives data at its true physical offset.

### ✅ Verification
- All 37 workspace tests pass.
- Clean `cargo clippy`.

This marks the completion of the core v2 integration (Issue #68)!