### PR TITLE
chore: integrate cargo doc and unify developer workflow with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ green-loop: fmt check test clippy fmt-check
 docs:
 	cd aura-docs/manual && mdbook build
 
+# Build the Rust API documentation
+docs-api:
+	cargo doc --workspace --no-deps --document-private-items
+
+# Build both Manual and API docs
+docs-all: docs docs-api
+
 # Serve the manual locally
 docs-serve:
 	cd aura-docs/manual && mdbook serve

--- a/aura-dev/SKILL.md
+++ b/aura-dev/SKILL.md
@@ -11,7 +11,7 @@ This skill transforms Gemini CLI into an **Expert Rust Specialist** for the Aura
 Every code change MUST finish with a successful execution of the "Green Loop". You are NOT finished until this passes with zero warnings:
 
 ```bash
-cargo fmt && cargo check && cargo test && cargo clippy -- -D warnings && cargo fmt --check
+make green-loop
 ```
 
 ## 🛠️ Workflows
@@ -22,15 +22,18 @@ cargo fmt && cargo check && cargo test && cargo clippy -- -D warnings && cargo f
 3.  **GREEN**: Implement the minimal logic to pass the test.
 4.  **REFACTOR**: Apply Rust Specialist principles (no unwraps, minimal cloning, idiomatic iterators).
 5.  **Audit**: Ensure the file is under **400 lines**. If not, decompose into sub-modules.
-6.  **Verify**: Run the "Green Loop".
+6.  **Verify**: Run `make green-loop`.
 
 ### 2. Real-World Scenario Testing
 Always verify changes against actual network resources:
--   **CLI**: `cargo run -p aura-cli -- "URL"`
+-   **CLI**: `make run-cli ARGS="URL"`
+-   **Daemon**: `make run-daemon`
+-   **Dashboard**: `make run-tui`
 -   **Control Files**: Verify `.aura` files are created/deleted correctly.
 -   **VPN/Interface**: Test binding with dummy interfaces if possible.
 
 ### 3. Documentation & ADR Sync
+-   **Build Manual**: Run `make docs` to verify the mdBook manual builds correctly.
 -   **Update ADRs**: If an architectural decision changes, update the relevant file in `aura-docs/adr/`.
 -   **Update TASKS**: Mark items as `[x]` in `aura-docs/project/TASKS.md` after completion.
 -   **Ubiquitous Language**: Add new domain terms to `aura-docs/project/CONTEXT.md`.

--- a/aura-docs/manual/src/SUMMARY.md
+++ b/aura-docs/manual/src/SUMMARY.md
@@ -21,6 +21,7 @@
 # Developer Documentation
 
 - [Architecture](./advanced/architecture.md)
+- [API Documentation (rustdoc)](./advanced/api-docs.md)
 - [BDD Testing Suite](./advanced/testing.md)
 - [ADR Index](./advanced/adr-index.md)
 

--- a/aura-docs/manual/src/advanced/api-docs.md
+++ b/aura-docs/manual/src/advanced/api-docs.md
@@ -1,0 +1,31 @@
+# API Documentation (rustdoc)
+
+Aura's codebase is extensively documented using standard Rust doc comments. This documentation provides a deep-dive into the internal types, traits, and functions that power the engine.
+
+## Generating the Documentation
+
+To build the internal API documentation locally, run:
+
+```bash
+make docs-api
+```
+
+This uses `cargo doc` with the following flags:
+- `--workspace`: Generates documentation for all crates in the workspace (`aura-core`, `aura-cli`, etc.).
+- `--no-deps`: Skips generating documentation for external dependencies to speed up the process.
+- `--document-private-items`: Includes internal (non-public) items to provide full visibility for developers.
+
+## Viewing the Documentation
+
+Once generated, the documentation is available in the `target/doc/` directory. You can open it in your browser:
+
+```bash
+open target/doc/aura_core/index.html
+```
+
+## Key Modules to Explore
+
+- **`aura_core::orchestrator`**: The central actor and task management logic.
+- **`aura_core::storage`**: Asynchronous disk I/O and write aggregation.
+- **`aura_core::worker`**: Protocol-specific fetching logic for HTTP, FTP, and BitTorrent.
+- **`aura_core::throttler`**: Global and per-task bandwidth rate-limiting.


### PR DESCRIPTION
This PR integrates `cargo doc` into the project's documentation workflow and updates the developer skill for consistency.

**Changes:**
- **Makefile Improvements**: Added `make docs-api` (runs `cargo doc --workspace --no-deps --document-private-items`) and `make docs-all`.
- **User Manual Expansion**: Added a new chapter on **API Documentation (rustdoc)**, explaining how to generate and explore internal code docs.
- **Skill Update**: Updated the `aura-dev` skill instructions to use `make` commands instead of raw `cargo` calls, ensuring a unified entry point for all developer tasks.
- **Cleanup**: Synchronized the branch with the latest `main` (which now includes the earlier audit and manual setup).

This ensures that internal technical documentation is as accessible as the high-level user manual.