### PR TITLE
feat: implement BitTorrent v2 Merkle tree verification (Issue #9)

### DIFF
--- a/aura-core/src/bt_worker/logic.rs
+++ b/aura-core/src/bt_worker/logic.rs
@@ -5,7 +5,6 @@ use crate::storage::StorageRequest;
 use crate::{Error, Result, TaskId};
 use futures_util::SinkExt;
 use sha1::{Digest, Sha1};
-use sha2::Sha256;
 use tokio_util::codec::Framed;
 use tracing::{debug, error, info};
 
@@ -89,10 +88,9 @@ impl super::BtWorker {
             if self.bytes_received >= piece_total_len {
                 // Piece complete, verify hash
                 let is_verified = if torrent.info_hash_v2().unwrap_or(None).is_some() {
-                    // v2 or Hybrid: use SHA-256
-                    let mut hasher = Sha256::new();
-                    hasher.update(&self.piece_buffer);
-                    let actual_hash: [u8; 32] = hasher.finalize().into();
+                    // v2 or Hybrid: use SHA-256 Merkle root
+                    let actual_hash =
+                        crate::torrent::Torrent::compute_piece_merkle_root(&self.piece_buffer);
 
                     if let Ok(expected_hash) =
                         torrent.piece_hash_v2(piece_idx, Some(&task.state.db))

--- a/aura-core/src/torrent/logic.rs
+++ b/aura-core/src/torrent/logic.rs
@@ -318,4 +318,46 @@ impl Torrent {
             "Piece index out of range for v2".to_string(),
         ))
     }
+
+    /// Computes the SHA-256 Merkle root of a piece according to BEP 52.
+    /// The piece is divided into 16KiB blocks. The block hashes are the leaves.
+    /// The tree is padded with 32-byte zero hashes to a power of two.
+    pub fn compute_piece_merkle_root(data: &[u8]) -> [u8; 32] {
+        const BLOCK_SIZE: usize = 16384;
+        if data.is_empty() {
+            return [0; 32];
+        }
+
+        let mut leaves: Vec<[u8; 32]> = data
+            .chunks(BLOCK_SIZE)
+            .map(|chunk| {
+                let mut hasher = Sha256::new();
+                hasher.update(chunk);
+                hasher.finalize().into()
+            })
+            .collect();
+
+        if leaves.is_empty() {
+            return [0; 32];
+        }
+
+        // Pad to next power of two with zero hashes
+        let next_pow2 = leaves.len().next_power_of_two();
+        leaves.resize(next_pow2, [0; 32]);
+
+        let mut current_level = leaves;
+
+        while current_level.len() > 1 {
+            let mut next_level = Vec::with_capacity(current_level.len() / 2);
+            for pair in current_level.chunks(2) {
+                let mut hasher = Sha256::new();
+                hasher.update(pair[0]);
+                hasher.update(pair[1]);
+                next_level.push(hasher.finalize().into());
+            }
+            current_level = next_level;
+        }
+
+        current_level[0]
+    }
 }

--- a/aura-docs/adr/0001-orchestrated-pull-model.md
+++ b/aura-docs/adr/0001-orchestrated-pull-model.md
@@ -26,5 +26,5 @@ We will use an **Orchestrated Pull** model.
 - **Logic**: Orchestrator listens for `SubTaskEvent` and assigns pieces via the `PiecePicker`.
 
 ## Verification
-- **Unit Test**: `aura-core/src/piece_picker.rs` (Tests piece selection strategy).
+- **Unit Test**: `aura-core/src/piece_picker/logic.rs` (Tests piece selection strategy).
 - **Integration Test**: `aura-core/src/bt_worker/tests.rs` (Simulates worker requesting work).

--- a/aura-docs/adr/0011-dynamic-configuration.md
+++ b/aura-docs/adr/0011-dynamic-configuration.md
@@ -25,4 +25,4 @@ Implemented
 - **Logic**: Uses `notify` crate to watch `Aura.toml` and updates `ArcSwap<Config>` inside the `Engine`.
 
 ## Verification
-- **Test**: `aura-core/src/config.rs` (Validates TOML parsing and default overrides).
+- **Test**: `aura-core/src/config/logic.rs` (Validates TOML parsing and default overrides).

--- a/aura-docs/project/ARCHITECTURE.md
+++ b/aura-docs/project/ARCHITECTURE.md
@@ -229,20 +229,20 @@ This table maps architectural concepts to their primary implementation files in 
 | **The Pilot (TUI)** | Interface | `aura-tui/src/app.rs`, `ui.rs` |
 | **Aura Daemon** | Persistent | `aura-daemon/src/main.rs` |
 | **Engine Core** | Orchestration | `aura-core/src/orchestrator/engine.rs` |
-| **Task Orchestrator** | Orchestration | `aura-core/src/orchestrator/mod.rs` |
-| **Sequential Aggregator** | Storage | `aura-core/src/storage/mod.rs` |
+| **Task Orchestrator** | Orchestration | `aura-core/src/orchestrator/logic.rs` |
+| **Sequential Aggregator** | Storage | `aura-core/src/storage/logic.rs` |
 | **Storage Ops** | Storage | `aura-core/src/storage/ops.rs` |
-| **Buffer Pool** | Memory | `aura-core/src/buffer_pool.rs` |
+| **Buffer Pool** | Memory | `aura-core/src/buffer_pool/logic.rs` |
 | **HTTP Worker** | Protocol | `aura-core/src/worker/http.rs` |
 | **FTP Worker** | Protocol | `aura-core/src/worker/ftp.rs` |
-| **BitTorrent Logic** | Protocol | `aura-core/src/bt_worker/logic.rs` |
-| **Piece Picker** | Strategy | `aura-core/src/piece_picker.rs` |
-| **Peer Registry** | Strategy | `aura-core/src/peer_registry.rs` |
-| **DHT Node** | Discovery | `aura-core/src/dht/mod.rs` |
-| **Tracker Client** | Discovery | `aura-core/src/tracker/mod.rs` |
-| **Power Manager** | System | `aura-core/src/power.rs` |
-| **NAT Traversal** | Network | `aura-core/src/nat.rs` |
-| **LPD** | Discovery | `aura-core/src/lpd.rs` |
+| **BitTorrent Logic** | Protocol | `aura-core/src/bt_worker/worker.rs` |
+| **Piece Picker** | Strategy | `aura-core/src/piece_picker/logic.rs` |
+| **Peer Registry** | Strategy | `aura-core/src/peer_registry/logic.rs` |
+| **DHT Node** | Discovery | `aura-core/src/dht/actor/mod.rs` |
+| **Tracker Client** | Discovery | `aura-core/src/tracker/logic.rs` |
+| **Power Manager** | System | `aura-core/src/power/logic.rs` |
+| **NAT Traversal** | Network | `aura-core/src/nat/logic.rs` |
+| **LPD** | Discovery | `aura-core/src/lpd/logic.rs` |
 
 ---
 

--- a/aura-docs/project/TASKS.md
+++ b/aura-docs/project/TASKS.md
@@ -8,8 +8,8 @@ This document tracks the technical debt and missing features identified during t
     - Implement COW-awareness (`chattr +C`) for Btrfs/ZFS.
     - Implement Windows long path prefixing (`\\?\`).
 - [x] **Modular Architecture Refactor** (Issue #96)
-    - Decompose `aura-core/src/torrent.rs` (461 lines) into `torrent/`.
-    - Decompose `aura-core/src/dht/mod.rs` (445 lines).
+    - Decompose `aura-core/src/torrent/` (was 461 lines) into sub-modules.
+    - Decompose `aura-core/src/dht/` (was 445 lines) into sub-modules.
 
 ## 🟡 Medium Priority: Connectivity & UX
 - [ ] **Browser Extension Bridge** (Issue #95)


### PR DESCRIPTION
This PR implements the missing SHA-256 Merkle tree verification logic for BitTorrent v2 as described in Issue #9 and ADR 0031.

### Changes
- Implemented `compute_piece_merkle_root` in `aura-core/src/torrent/logic.rs` to correctly split downloaded pieces into 16KB blocks, hash them, and compute the padded Merkle root as required by BEP 52.
- Updated `aura-core/src/bt_worker/logic.rs` to use this new function to verify v2/hybrid pieces instead of erroneously doing a flat SHA-256 hash over the entire piece buffer.
- Removed unused `sha2::Sha256` imports and resolved `clippy::needless_borrows_for_generic_args` warnings to maintain the strict `aura-dev` Green Loop requirements.

Closes #9.