### PR TITLE
fix: smooth HTTP chunk processing to resolve flaky throttler tests

### DIFF
--- a/aura-core/src/worker/http.rs
+++ b/aura-core/src/worker/http.rs
@@ -162,14 +162,23 @@ impl ProtocolWorker for HttpWorker {
 
         while let Some(chunk_res) = stream.next().await {
             let chunk = chunk_res.map_err(|e| Error::Protocol(format!("Stream error: {}", e)))?;
-            let chunk_len = chunk.len() as u64;
+            
+            let mut remaining_chunk = &chunk[..];
+            while !remaining_chunk.is_empty() {
+                // Process in chunks of 16KB to prevent bursty progress reporting 
+                // that skews the EWMA throughput calculations.
+                let take_len = std::cmp::min(remaining_chunk.len(), 16384);
+                let sub_chunk = &remaining_chunk[..take_len];
+                
+                // Admission Control: Wait for bandwidth tokens before processing the sub-chunk
+                throttler.acquire_download(task_id, take_len as u64).await;
 
-            // Admission Control: Wait for bandwidth tokens before processing the chunk
-            throttler.acquire_download(task_id, chunk_len).await;
-
-            buffer.extend_from_slice(&chunk);
-            if let Some(ref p_tx) = progress {
-                let _ = p_tx.send(chunk_len);
+                buffer.extend_from_slice(sub_chunk);
+                if let Some(ref p_tx) = progress {
+                    let _ = p_tx.send(take_len as u64);
+                }
+                
+                remaining_chunk = &remaining_chunk[take_len..];
             }
         }
 

--- a/aura-core/src/worker/http.rs
+++ b/aura-core/src/worker/http.rs
@@ -162,14 +162,14 @@ impl ProtocolWorker for HttpWorker {
 
         while let Some(chunk_res) = stream.next().await {
             let chunk = chunk_res.map_err(|e| Error::Protocol(format!("Stream error: {}", e)))?;
-            
+
             let mut remaining_chunk = &chunk[..];
             while !remaining_chunk.is_empty() {
-                // Process in chunks of 16KB to prevent bursty progress reporting 
+                // Process in chunks of 16KB to prevent bursty progress reporting
                 // that skews the EWMA throughput calculations.
                 let take_len = std::cmp::min(remaining_chunk.len(), 16384);
                 let sub_chunk = &remaining_chunk[..take_len];
-                
+
                 // Admission Control: Wait for bandwidth tokens before processing the sub-chunk
                 throttler.acquire_download(task_id, take_len as u64).await;
 
@@ -177,7 +177,7 @@ impl ProtocolWorker for HttpWorker {
                 if let Some(ref p_tx) = progress {
                     let _ = p_tx.send(take_len as u64);
                 }
-                
+
                 remaining_chunk = &remaining_chunk[take_len..];
             }
         }

--- a/aura-docs/project/ROADMAP.md
+++ b/aura-docs/project/ROADMAP.md
@@ -59,11 +59,15 @@
 - [x] **Power Management** (OS-level sleep assertions).
 
 ## 🚀 Milestone 7: Industrial Hardening (Proposed)
-- [ ] **Advanced Disk I/O Scheduling** (Deadline-based sorted writes) (ADR 0022).
-- [ ] **Unified Credential Provider** (Netrc/Cookie management) (ADR 0014).
-- [ ] **Multi-tenancy & Quotas** (Resource isolation) (ADR 0032).
-- [ ] **No-COW Allocator** (Btrfs/ZFS fragmentation prevention).
-- [ ] **Recursive Mirroring** (Wget-style site crawling).
+- [ ] **Advanced Disk I/O Scheduling** (Deadline-based sorted writes) (Issue #13).
+- [ ] **Unified Credential Provider** (Netrc/Cookie management) (Issue #21).
+- [ ] **Multi-tenancy & Quotas** (Resource isolation) (Issue #15).
+- [x] **No-COW Allocator** (Btrfs/ZFS fragmentation prevention) (Issue #92).
+- [ ] **Recursive Mirroring** (Wget-style site crawling) (Issue #65).
+- [ ] **Generational Write Buffer & Advanced Caching** (Issue #14).
+- [ ] **Task Chaining & Metadata-based Path Mapping** (Issue #11).
+- [ ] **Network Filesystem (NFS/SMB) Optimizations** (Issue #12).
+- [ ] **Integrity Scrubbing & Self-healing Storage** (Issue #4).
 
 ## 🛡️ Infrastructure & DevSecOps
 - [x] `GEMINI.md` (Engineering Mandates).


### PR DESCRIPTION
### Description
This PR resolves the new CI failure on the `main` branch caused by flaky BDD tests in the `Hierarchical task-level throttling` scenario.

### Root Cause
While previous PRs fixed the race condition around configuration reloading, the underlying HTTP worker (`reqwest`/`hyper`) was still yielding large byte chunks from the socket. The `HttpWorker` would block to acquire tokens for the entire large chunk (e.g., 256KB) and then instantly report it to the `EventBus`. This caused the Orchestrator's EWMA (Exponential Moving Average) throughput calculation to register a massive, instantaneous artificial spike, exceeding the test's strict throughput limits and causing a panic.

### Fix
- Modified `aura-core/src/worker/http.rs` to slice large incoming HTTP chunks into 16KB sub-chunks.
- Tokens are now acquired, and progress is reported to the Orchestrator, sequentially for each 16KB sub-chunk.
- This ensures the EWMA calculation reflects a smooth, accurate transfer rate rather than a single massive spike.
- Also includes a minor sync of `ROADMAP.md` that was left uncommitted.

All tests pass locally and the BDD throttling scenarios are now deterministic.