### PR TITLE
feat: HSTS Cache & Automated HTTPS Upgrade

### DIFF
--- a/aura-core/src/lib.rs
+++ b/aura-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod vpn;
 pub mod worker;
 
 pub mod config;
+pub mod security;
 
 pub use api::{TaskEvent, TaskHandle};
 pub use config::Config;

--- a/aura-core/src/orchestrator/commands.rs
+++ b/aura-core/src/orchestrator/commands.rs
@@ -345,6 +345,7 @@ impl Orchestrator {
             let local_addr = self.resolve_local_addr();
             let provider_clone = self.credential_provider.clone();
             let dns_resolver = self.dns_resolver.clone();
+            let hsts_cache = self.hsts_cache.clone();
 
             tracing::info!(%id, %sub_id, %uri, "Retrying/Self-healing Degraded subtask");
 
@@ -362,6 +363,7 @@ impl Orchestrator {
                             .retry_count(config.network.http_retry_count)
                             .retry_delay_secs(config.network.http_retry_delay_secs)
                             .credential_provider(provider_clone)
+                            .hsts_cache(hsts_cache)
                             .build_http();
                         match worker.resolve_metadata().await {
                             Ok(m) => {

--- a/aura-core/src/orchestrator/lifecycle/lifecycle_ext.rs
+++ b/aura-core/src/orchestrator/lifecycle/lifecycle_ext.rs
@@ -139,6 +139,7 @@ impl Orchestrator {
                 let throttler_clone = self.throttler.clone();
                 let provider_clone = self.credential_provider.clone();
                 let dns_resolver = self.dns_resolver.clone();
+                let hsts_cache = self.hsts_cache.clone();
 
                 let subtask_tx_progress = subtask_tx.clone();
                 let progress_handle = tokio::spawn(async move {
@@ -162,6 +163,7 @@ impl Orchestrator {
                                 .retry_count(config.network.http_retry_count)
                                 .retry_delay_secs(config.network.http_retry_delay_secs)
                                 .credential_provider(provider_clone)
+                                .hsts_cache(hsts_cache)
                                 .build_http();
                             let segment = Segment {
                                 offset: range.start,

--- a/aura-core/src/orchestrator/lifecycle/mod.rs
+++ b/aura-core/src/orchestrator/lifecycle/mod.rs
@@ -80,6 +80,7 @@ impl Orchestrator {
             let throttler_clone = throttler_arc.clone();
             let provider_clone = self.credential_provider.clone();
             let dns_resolver = self.dns_resolver.clone();
+            let hsts_cache = self.hsts_cache.clone();
 
             let existing_bt = self.bt_tasks.get(&sub_id).cloned();
 
@@ -97,6 +98,7 @@ impl Orchestrator {
                             .retry_count(config.network.http_retry_count)
                             .retry_delay_secs(config.network.http_retry_delay_secs)
                             .credential_provider(provider_clone.clone())
+                            .hsts_cache(hsts_cache)
                             .build_http();
                         match worker.resolve_metadata().await {
                             Ok(m) => {

--- a/aura-core/src/orchestrator/logic.rs
+++ b/aura-core/src/orchestrator/logic.rs
@@ -122,6 +122,7 @@ pub struct Orchestrator {
     pub(crate) dns_resolver: Arc<crate::net_util::TokioResolver>,
     pub(crate) pool: BufferPool,
     pub(crate) db: sled::Db,
+    pub(crate) hsts_cache: crate::security::HstsCache,
 }
 
 impl Orchestrator {
@@ -323,6 +324,7 @@ impl Orchestrator {
                 dns_resolver,
                 pool,
                 db,
+                hsts_cache: crate::security::HstsCache::new(),
             },
             event_tx,
         )

--- a/aura-core/src/security/mod.rs
+++ b/aura-core/src/security/mod.rs
@@ -1,0 +1,193 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HstsPolicy {
+    pub domain: String,
+    pub expiry: u64, // unix timestamp in seconds
+    pub include_subdomains: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HstsCacheInner {
+    pub policies: HashMap<String, HstsPolicy>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HstsCache {
+    inner: Arc<RwLock<HstsCacheInner>>,
+}
+
+impl Default for HstsCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HstsCache {
+    pub fn new() -> Self {
+        let cache = Self::load();
+        Self {
+            inner: Arc::new(RwLock::new(cache)),
+        }
+    }
+
+    pub fn load() -> HstsCacheInner {
+        let path = std::path::Path::new(".aura/hsts.json");
+        if path.exists() {
+            if let Ok(data) = std::fs::read_to_string(path) {
+                if let Ok(cache) = serde_json::from_str::<HstsCacheInner>(&data) {
+                    return cache;
+                }
+            }
+        }
+        HstsCacheInner::default()
+    }
+
+    pub async fn save(&self) {
+        let inner = self.inner.read().await;
+        let _ = std::fs::create_dir_all(".aura");
+        if let Ok(data) = serde_json::to_string_pretty(&*inner) {
+            let _ = std::fs::write(".aura/hsts.json", data);
+        }
+    }
+
+    pub async fn should_upgrade(&self, domain: &str) -> bool {
+        let inner = self.inner.read().await;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        // Normalize domain
+        let domain_lower = domain.to_lowercase();
+
+        // Safeguard: Never upgrade localhost or loopback IP addresses
+        if domain_lower == "127.0.0.1" || domain_lower == "localhost" || domain_lower == "::1" {
+            return false;
+        }
+
+        // 1. Direct match
+        if let Some(policy) = inner.policies.get(&domain_lower) {
+            if policy.expiry > now {
+                return true;
+            }
+        }
+
+        // 2. Subdomain match
+        let parts: Vec<&str> = domain_lower.split('.').collect();
+        for i in 1..parts.len() {
+            let parent_domain = parts[i..].join(".");
+            if let Some(policy) = inner.policies.get(&parent_domain) {
+                if policy.include_subdomains && policy.expiry > now {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    pub async fn insert_policy(&self, domain: String, max_age: u64, include_subdomains: bool) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let expiry = now + max_age;
+        let domain_lower = domain.to_lowercase();
+
+        {
+            let mut inner = self.inner.write().await;
+            inner.policies.insert(
+                domain_lower.clone(),
+                HstsPolicy {
+                    domain: domain_lower,
+                    expiry,
+                    include_subdomains,
+                },
+            );
+        }
+
+        self.save().await;
+    }
+}
+
+/// Parses the Strict-Transport-Security header value (e.g. "max-age=31536000; includeSubDomains").
+pub fn parse_hsts_header(value: &str) -> Option<(u64, bool)> {
+    let mut max_age = None;
+    let mut include_subdomains = false;
+
+    for part in value.split(';') {
+        let trimmed = part.trim();
+        if trimmed.to_lowercase().starts_with("max-age=") {
+            if let Ok(parsed) = trimmed["max-age=".len()..].trim().parse::<u64>() {
+                max_age = Some(parsed);
+            }
+        } else if trimmed.eq_ignore_ascii_case("includeSubDomains") {
+            include_subdomains = true;
+        }
+    }
+
+    max_age.map(|age| (age, include_subdomains))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_hsts_header() {
+        assert_eq!(
+            parse_hsts_header("max-age=31536000"),
+            Some((31536000, false))
+        );
+        assert_eq!(
+            parse_hsts_header("max-age=600; includeSubDomains"),
+            Some((600, true))
+        );
+        assert_eq!(
+            parse_hsts_header("includeSubDomains; max-age=1200"),
+            Some((1200, true))
+        );
+        assert_eq!(parse_hsts_header("invalid-header"), None);
+    }
+
+    #[tokio::test]
+    async fn test_hsts_cache_upgrades() {
+        let cache = HstsCache::new();
+        let domain = "secure-example.com".to_string();
+
+        // Initially no policy, so should not upgrade
+        assert!(!cache.should_upgrade(&domain).await);
+
+        // Add HSTS policy with 60s max-age
+        cache.insert_policy(domain.clone(), 60, false).await;
+        assert!(cache.should_upgrade(&domain).await);
+
+        // Subdomain should not upgrade since include_subdomains is false
+        assert!(!cache.should_upgrade("sub.secure-example.com").await);
+
+        // Expiration check (simulated with 0 max-age)
+        cache.insert_policy(domain.clone(), 0, false).await;
+        // Small delay just to be completely sure expiry is not in exact same second
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(!cache.should_upgrade(&domain).await);
+    }
+
+    #[tokio::test]
+    async fn test_hsts_subdomain_matching() {
+        let cache = HstsCache::new();
+        let domain = "parent.com".to_string();
+
+        cache.insert_policy(domain.clone(), 300, true).await;
+        assert!(cache.should_upgrade(&domain).await);
+        // Subdomains should also be upgraded
+        assert!(cache.should_upgrade("sub.parent.com").await);
+        assert!(cache.should_upgrade("deep.sub.parent.com").await);
+
+        // Mismatched domain should not upgrade
+        assert!(!cache.should_upgrade("otherparent.com").await);
+    }
+}

--- a/aura-core/src/worker/builder.rs
+++ b/aura-core/src/worker/builder.rs
@@ -16,6 +16,7 @@ pub struct WorkerBuilder {
     retry_delay_secs: u64,
     credential_provider: Option<std::sync::Arc<crate::config::credentials::CredentialProvider>>,
     dns_resolver: Option<std::sync::Arc<crate::net_util::TokioResolver>>,
+    hsts_cache: Option<crate::security::HstsCache>,
 }
 
 impl WorkerBuilder {
@@ -32,6 +33,7 @@ impl WorkerBuilder {
             retry_delay_secs: 2,
             credential_provider: None,
             dns_resolver: None,
+            hsts_cache: None,
         }
     }
 
@@ -40,6 +42,11 @@ impl WorkerBuilder {
         resolver: std::sync::Arc<crate::net_util::TokioResolver>,
     ) -> Self {
         self.dns_resolver = Some(resolver);
+        self
+    }
+
+    pub fn hsts_cache(mut self, cache: crate::security::HstsCache) -> Self {
+        self.hsts_cache = Some(cache);
         self
     }
 
@@ -104,6 +111,7 @@ impl WorkerBuilder {
             self.retry_delay_secs,
             self.credential_provider,
             self.dns_resolver,
+            self.hsts_cache,
         )
     }
 

--- a/aura-core/src/worker/http.rs
+++ b/aura-core/src/worker/http.rs
@@ -14,11 +14,57 @@ pub struct HttpWorker {
     retry_count: u32,
     retry_delay_secs: u64,
     credential_provider: Option<std::sync::Arc<crate::config::credentials::CredentialProvider>>,
+    hsts_cache: Option<crate::security::HstsCache>,
 }
 
 impl HttpWorker {
     fn is_retryable(status: reqwest::StatusCode) -> bool {
         status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+    }
+
+    async fn upgrade_url(&self, url_str: &str) -> String {
+        if let Some(ref cache) = self.hsts_cache {
+            if let Ok(mut url) = url::Url::parse(url_str) {
+                if url.scheme() == "http" {
+                    if let Some(host) = url.host_str() {
+                        if cache.should_upgrade(host).await {
+                            let _ = url.set_scheme("https");
+                            tracing::info!(
+                                from = url_str,
+                                to = url.as_str(),
+                                "HSTS: Automatically upgraded HTTP request to HTTPS"
+                            );
+                            return url.to_string();
+                        }
+                    }
+                }
+            }
+        }
+        url_str.to_string()
+    }
+
+    async fn check_and_update_hsts(&self, resp: &reqwest::Response) {
+        if let Some(ref cache) = self.hsts_cache {
+            let url = resp.url();
+            if url.scheme() == "https" {
+                if let Some(hsts_val) = resp
+                    .headers()
+                    .get(reqwest::header::STRICT_TRANSPORT_SECURITY)
+                {
+                    if let Ok(hsts_str) = hsts_val.to_str() {
+                        if let Some((max_age, include_subdomains)) =
+                            crate::security::parse_hsts_header(hsts_str)
+                        {
+                            if let Some(host) = url.host_str() {
+                                cache
+                                    .insert_policy(host.to_string(), max_age, include_subdomains)
+                                    .await;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -34,6 +80,7 @@ impl HttpWorker {
         retry_delay_secs: u64,
         credential_provider: Option<std::sync::Arc<crate::config::credentials::CredentialProvider>>,
         dns_resolver: Option<std::sync::Arc<crate::net_util::TokioResolver>>,
+        hsts_cache: Option<crate::security::HstsCache>,
     ) -> Self {
         let cookie_jar = if let Some(ref provider) = credential_provider {
             provider.cookie_jar()
@@ -75,6 +122,7 @@ impl HttpWorker {
             retry_count,
             retry_delay_secs,
             credential_provider,
+            hsts_cache,
         }
     }
 
@@ -88,6 +136,7 @@ impl HttpWorker {
         let link_regex = regex::Regex::new(r#"(?i)<a\s+[^>]*href=["']([^"']+)["']"#).unwrap();
 
         loop {
+            current_uri = self.upgrade_url(&current_uri).await;
             let mut attempts = 0;
             let max_attempts = self.retry_count;
 
@@ -113,6 +162,7 @@ impl HttpWorker {
 
                 match res {
                     Ok(resp) => {
+                        self.check_and_update_hsts(&resp).await;
                         if resp.status().is_success() || resp.status().is_redirection() {
                             break resp;
                         } else if Self::is_retryable(resp.status()) && attempts < max_attempts {
@@ -280,19 +330,20 @@ impl ProtocolWorker for HttpWorker {
         let max_attempts = self.retry_count;
 
         loop {
+            let upgraded_uri = self.upgrade_url(&self.uri).await;
             let range_header = format!(
                 "bytes={}-{}",
                 segment.offset,
                 segment.offset + segment.length - 1
             );
-            let mut request = self.client.get(&self.uri).header("Range", range_header);
+            let mut request = self.client.get(&upgraded_uri).header("Range", range_header);
 
             if let Some(ref ref_uri) = self.referer {
                 request = request.header("Referer", ref_uri);
             }
 
             if let Some(ref provider) = self.credential_provider {
-                if let Ok(url) = url::Url::parse(&self.uri) {
+                if let Ok(url) = url::Url::parse(&upgraded_uri) {
                     if let Some(host) = url.host_str() {
                         if let Some(creds) = provider.get_credentials(host) {
                             if let (Some(user), Some(pass)) = (&creds.login, &creds.password) {
@@ -307,6 +358,7 @@ impl ProtocolWorker for HttpWorker {
 
             match response_res {
                 Ok(response) => {
+                    self.check_and_update_hsts(&response).await;
                     if response.status().is_success() {
                         let mut buffer = if let Some(ref p) = self.pool {
                             p.acquire()
@@ -433,6 +485,7 @@ mod tests {
             2,
             None,
             None,
+            None,
         );
         let metadata = worker
             .resolve_metadata()
@@ -449,6 +502,7 @@ mod tests {
             None,
             5,
             2,
+            None,
             None,
             None,
         );
@@ -494,6 +548,7 @@ mod tests {
             2,
             None,
             None,
+            None,
         );
         let result = worker.resolve_metadata().await;
         match result {
@@ -526,6 +581,7 @@ mod tests {
             2,
             None,
             Some(resolver_arc),
+            None,
         );
 
         let metadata = worker.resolve_metadata().await.expect("Should resolve");
@@ -561,6 +617,7 @@ mod tests {
             None,
             3, // Max retries
             1, // 1s base delay
+            None,
             None,
             None,
         );
@@ -625,6 +682,7 @@ mod tests {
             1,
             None,
             None,
+            None,
         );
 
         let result = worker.resolve_metadata().await;
@@ -668,6 +726,7 @@ mod tests {
             1,
             None,
             None,
+            None,
         );
 
         let result = worker.resolve_metadata().await;
@@ -676,5 +735,32 @@ mod tests {
             Err(Error::Protocol(msg)) => assert!(msg.contains("Direct link resolution failed")),
             _ => panic!("Expected Protocol error for HTML landing page failure"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_http_worker_hsts_upgrade() {
+        let hsts_cache = crate::security::HstsCache::new();
+        let host = "example.com".to_string();
+        hsts_cache.insert_policy(host, 300, true).await;
+
+        // Create a worker with an insecure http URL
+        let http_uri = "http://example.com/file".to_string();
+        let worker = HttpWorker::new(
+            http_uri,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            3,
+            1,
+            None,
+            None,
+            Some(hsts_cache),
+        );
+
+        let upgraded = worker.upgrade_url(&worker.uri).await;
+        assert_eq!(upgraded, "https://example.com/file");
     }
 }


### PR DESCRIPTION
## Description

This PR implements a persisted, thread-safe HSTS (Strict-Transport-Security) Cache in Aura, automatically upgrading insecure HTTP requests to HTTPS based on HSTS policies (as specified in ADR 0018).

It introduces:
- `HstsPolicy`, `HstsCacheInner`, and the thread-safe `HstsCache` persisted to `.aura/hsts.json`.
- Standard header parsing for `Strict-Transport-Security` matching `max-age` and `includeSubDomains`.
- Support for parent-domain HSTS upgrades (matching subdomains if `includeSubDomains = true`).
- Dynamic URL protocol upgrading inside `HttpWorker` GET requests in `resolve_metadata` and `fetch_segment`.
- Response header inspection to extract HSTS policies from all successful/redirected secure HTTPS responses.
- Safeguard mechanism to explicitly exclude loopback IPs (`127.0.0.1`, `::1`) or local domains (`localhost`) from being HSTS upgraded, guaranteeing that test mock environments never get HSTS-polluted.

Fixes #20

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)