### PR TITLE
feat: Dual-Stack Asynchronous DNS Racing (Happy Eyeballs)

### DIFF
--- a/aura-core/src/net_util/resolver.rs
+++ b/aura-core/src/net_util/resolver.rs
@@ -239,13 +239,33 @@ impl reqwest::dns::Resolve for ReqwestDnsResolver {
                 .lookup_ip(name_str)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
-            let addrs: Box<dyn Iterator<Item = std::net::SocketAddr> + Send> = Box::new(
-                lookup
-                    .iter()
-                    .map(|ip| std::net::SocketAddr::new(ip, 0))
-                    .collect::<Vec<_>>()
-                    .into_iter(),
-            );
+
+            let mut ipv6_addrs = Vec::new();
+            let mut ipv4_addrs = Vec::new();
+            for ip in lookup.iter() {
+                if ip.is_ipv6() {
+                    ipv6_addrs.push(ip);
+                } else {
+                    ipv4_addrs.push(ip);
+                }
+            }
+
+            let mut resolved_addrs = Vec::new();
+            let mut i = 0;
+            let mut j = 0;
+            while i < ipv6_addrs.len() || j < ipv4_addrs.len() {
+                if i < ipv6_addrs.len() {
+                    resolved_addrs.push(std::net::SocketAddr::new(ipv6_addrs[i], 0));
+                    i += 1;
+                }
+                if j < ipv4_addrs.len() {
+                    resolved_addrs.push(std::net::SocketAddr::new(ipv4_addrs[j], 0));
+                    j += 1;
+                }
+            }
+
+            let addrs: Box<dyn Iterator<Item = std::net::SocketAddr> + Send> =
+                Box::new(resolved_addrs.into_iter());
             Ok(addrs)
         })
     }

--- a/aura-core/src/worker/ftp.rs
+++ b/aura-core/src/worker/ftp.rs
@@ -77,65 +77,16 @@ impl FtpWorker {
             pass = p;
         }
 
-        let mut ftp_stream = if let Some(local_ip) = self.local_addr {
-            let addrs = tokio::net::lookup_host(format!("{}:{}", host, port))
+        let tcp_stream =
+            crate::net_util::logic::connect_tcp_bound_host(host, port, None, self.local_addr, None)
                 .await
                 .map_err(|e| {
-                    Error::Worker(format!("Failed to resolve FTP host {}: {}", host, e))
+                    Error::Worker(format!("Failed to connect to FTP host {}: {}", host, e))
                 })?;
 
-            let mut last_err = None;
-            let mut tcp_stream = None;
-
-            for addr in addrs {
-                if addr.ip().is_ipv4() == local_ip.is_ipv4() {
-                    let socket = if local_ip.is_ipv4() {
-                        tokio::net::TcpSocket::new_v4()
-                    } else {
-                        tokio::net::TcpSocket::new_v6()
-                    }
-                    .map_err(|e| Error::Worker(format!("Failed to create socket: {}", e)))?;
-
-                    if let Err(e) = socket.bind(std::net::SocketAddr::new(local_ip, 0)) {
-                        last_err = Some(Error::Worker(format!(
-                            "Failed to bind to {}: {}",
-                            local_ip, e
-                        )));
-                        continue;
-                    }
-
-                    match socket.connect(addr).await {
-                        Ok(stream) => {
-                            tcp_stream = Some(stream);
-                            break;
-                        }
-                        Err(e) => {
-                            last_err = Some(Error::Worker(format!(
-                                "Failed to connect to {}: {}",
-                                addr, e
-                            )));
-                        }
-                    }
-                }
-            }
-
-            let tcp_stream = tcp_stream.ok_or_else(|| {
-                last_err.unwrap_or_else(|| {
-                    Error::Worker(format!(
-                        "No matching IP address found for host {} and local address {}",
-                        host, local_ip
-                    ))
-                })
-            })?;
-
-            AsyncNativeTlsFtpStream::connect_with_stream(tcp_stream)
-                .await
-                .map_err(|e| Error::Worker(format!("Failed to initialize FTP stream: {}", e)))?
-        } else {
-            AsyncNativeTlsFtpStream::connect(format!("{}:{}", host, port))
-                .await
-                .map_err(|e| Error::Worker(format!("Failed to connect to FTP: {}", e)))?
-        };
+        let mut ftp_stream = AsyncNativeTlsFtpStream::connect_with_stream(tcp_stream)
+            .await
+            .map_err(|e| Error::Worker(format!("Failed to initialize FTP stream: {}", e)))?;
 
         // Determine if we should upgrade to TLS.
         let is_ftps = url.scheme() == "ftps";

--- a/aura-docs/project/TASKS.md
+++ b/aura-docs/project/TASKS.md
@@ -8,7 +8,7 @@ All active development tasks, technical debt, and feature requests are managed e
 - [ ] **Feat: Add peer health scoring, reputation, and eviction to peer registry** (Issue #123) `[status:half-baked, module:core, priority:moderate]`
 - [ ] **feat: implement actual Recursive Crawler (Wget parity)** (Issue #65) `[status:half-baked, module:core, priority:moderate]`
 - [ ] **feat: implement Integrity Scrubber Actor and self-healing** (Issue #4) `[status:half-baked, module:storage, priority:moderate]`
-- [ ] **feat: Dual-Stack Asynchronous DNS Racing (Happy Eyeballs)** (Issue #25) `[status:missing, priority:moderate, module:network]`
+- [x] **feat: Dual-Stack Asynchronous DNS Racing (Happy Eyeballs)** (Issue #25) `[status:completed, priority:moderate, module:network]`
 - [ ] **infra: CI Docs Deployment** (Issue #134) `[enhancement, priority:moderate, infra]`
 - [ ] **Feat: Respect BEP 12 tracker tier ordering** (Issue #128) `[enhancement, module:core, priority:low]`
 - [ ] **Feat: Implement PEX (Peer Exchange) — BEP 11** (Issue #121) `[enhancement, module:core, priority:moderate]`


### PR DESCRIPTION
Fixes #25.

### What was changed:
- Interleaved IPv6 and IPv4 addresses in `ReqwestDnsResolver` to enable `hyper`'s built-in Happy Eyeballs support for HTTP connections.
- Replaced `FtpWorker`'s sequential connection loop with the `connect_tcp_bound_host` helper, enabling asynchronous dual-stack racing for FTP connections.
- Updated `TASKS.md` tracking.