### PR TITLE
fix: memory-efficient streaming, naming resolution, and path migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +685,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +914,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1170,8 +1194,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1841,6 +1876,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2554,12 +2598,12 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4329,7 +4373,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4340,7 +4384,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "md-5",
  "metrics",
  "metrics-exporter-prometheus",
+ "mime_guess",
  "nosleep",
  "notify",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +684,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +913,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1169,8 +1193,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1840,6 +1875,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2553,12 +2597,12 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4328,7 +4372,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4339,7 +4383,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ igd-next = { version = "0.17.0", features = ["aio_tokio", "tokio"] }
 indicatif = "0.18"
 local-ip-address = "0.6.12"
 lol_html = "2.0"
-md-5 = "0.10"
+md-5 = "0.11"
 metrics = "0.24.6"
 metrics-exporter-prometheus = "0.18.3"
 mime_guess = "2.0"

--- a/aura-cli/src/lib.rs
+++ b/aura-cli/src/lib.rs
@@ -36,11 +36,12 @@ pub async fn run(args: Args) -> Result<()> {
     let current_dir = std::env::current_dir().unwrap();
 
     // Register and add all tasks
+    let mut tasks_to_add = Vec::new();
     for uri in &expanded_uris {
         let path_obj = std::path::Path::new(uri);
         let is_local_file = path_obj.exists() && path_obj.is_file();
 
-        let (name, is_metadata) = if is_local_file
+        let (inferred_name, is_metadata) = if is_local_file
             && (uri.ends_with(".torrent") || uri.ends_with(".metalink") || uri.ends_with(".meta4"))
         {
             ("unnamed".to_string(), true)
@@ -64,25 +65,55 @@ pub async fn run(args: Args) -> Result<()> {
             )
         };
 
-        let path = current_dir.join(&name);
+        tasks_to_add.push((uri.clone(), inferred_name, is_metadata));
+    }
+
+    if tasks_to_add.is_empty() {
+        return Ok(());
+    }
+
+    // If output is specified, we treat all URIs as sources for that one output
+    if let Some(output_name) = &args.output {
         let id = TaskId(rand::rng().random());
-        if !is_metadata {
-            storage.register_task(id, path, 0, None);
+        let path = current_dir.join(output_name);
+        storage.register_task(id, path, 0, None).await;
+
+        let mut sources = Vec::new();
+        for (uri, _, _) in tasks_to_add {
+            let ttype = if uri.ends_with(".torrent") {
+                TaskType::BitTorrent
+            } else if uri.starts_with("ftp://") || uri.starts_with("ftps://") {
+                TaskType::Ftp
+            } else {
+                TaskType::Http
+            };
+            sources.push((uri, ttype));
         }
 
-        let ttype = if uri.ends_with(".torrent") || (is_local_file && uri.ends_with(".torrent")) {
-            TaskType::BitTorrent
-        } else if uri.ends_with(".metalink") || uri.ends_with(".meta4") {
-            // Orchestrator handles parsing if the type is Metalink-compatible (Http is used as a placeholder for parsing)
-            TaskType::Http
-        } else if uri.starts_with("ftp://") || uri.starts_with("ftps://") {
-            TaskType::Ftp
-        } else {
-            TaskType::Http
-        };
         engine
-            .add_task_with_id(id, name, uri.clone(), ttype)
+            .add_task_with_options(id, output_name.clone(), sources, None, 100, false)
             .await?;
+    } else {
+        for (uri, name, is_metadata) in tasks_to_add {
+            let path = current_dir.join(&name);
+            let id = TaskId(rand::rng().random());
+            if !is_metadata {
+                storage.register_task(id, path, 0, None).await;
+            }
+
+            let ttype = if uri.ends_with(".torrent") {
+                TaskType::BitTorrent
+            } else if uri.ends_with(".metalink") || uri.ends_with(".meta4") {
+                TaskType::Http
+            } else if uri.starts_with("ftp://") || uri.starts_with("ftps://") {
+                TaskType::Ftp
+            } else {
+                TaskType::Http
+            };
+            engine
+                .add_task_with_id(id, name, uri.clone(), ttype)
+                .await?;
+        }
     }
 
     // Spawn the actors

--- a/aura-core/Cargo.toml
+++ b/aura-core/Cargo.toml
@@ -42,6 +42,7 @@ metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 hickory-resolver = { workspace = true }
 lol_html = { workspace = true }
+mime_guess = { workspace = true }
 lru = "0.18.0"
 
 [dev-dependencies]

--- a/aura-core/benches/storage_bench.rs
+++ b/aura-core/benches/storage_bench.rs
@@ -16,7 +16,7 @@ fn bench_storage_sequential_write(c: &mut Criterion) {
     let (completion_tx, _completion_rx) = mpsc::channel(100);
     let mut storage = StorageEngine::new(request_rx, completion_tx, None);
     let id = TaskId(1);
-    storage.register_task(id, file_path, 0, None);
+    rt.block_on(storage.register_task(id, file_path, 0, None));
 
     rt.spawn(async move {
         storage.run().await.unwrap();
@@ -53,7 +53,7 @@ fn bench_storage_random_write_aggregated(c: &mut Criterion) {
     let (completion_tx, _completion_rx) = mpsc::channel(1000);
     let mut storage = StorageEngine::new(request_rx, completion_tx, None);
     let id = TaskId(2);
-    storage.register_task(id, file_path, 0, None);
+    rt.block_on(storage.register_task(id, file_path, 0, None));
 
     rt.spawn(async move {
         storage.run().await.unwrap();

--- a/aura-core/src/orchestrator/commands/add.rs
+++ b/aura-core/src/orchestrator/commands/add.rs
@@ -58,7 +58,7 @@ impl Orchestrator {
                                 if meta_task.total_length == 0 {
                                     if let Some(size) = file.size {
                                         meta_task.total_length = size;
-                                        meta_task.generate_ranges(16);
+                                        meta_task.generate_ranges(128);
                                     }
                                 }
                                 for res in file.resources {

--- a/aura-core/src/orchestrator/event_handlers.rs
+++ b/aura-core/src/orchestrator/event_handlers.rs
@@ -17,6 +17,7 @@ impl Orchestrator {
                 final_uri: format!("magnet:?xt={}", bt_task.state.info_hash.to_magnet_urn()),
                 total_length: Some(torrent.total_length()),
                 name: Some(torrent.info.name.clone()),
+                range_supported: true,
             };
             self.handle_subtask_matured(meta_id, sub_id, metadata)
                 .await?;
@@ -37,7 +38,22 @@ impl Orchestrator {
                 if let Some(len) = metadata.total_length {
                     info!(%meta_id, %len, "Metadata matured: task initialized");
                     meta_task.total_length = len;
-                    meta_task.generate_ranges(16); // Default 16 segments
+                    if metadata.range_supported {
+                        meta_task.generate_ranges(128); // Default 128 segments to allow high concurrency
+                    } else {
+                        info!(%meta_id, "Server does not support Range requests. Falling back to single-stream download.");
+                        meta_task
+                            .pending_ranges
+                            .push(crate::task::Range { start: 0, end: len });
+                    }
+                    needs_reregister = true;
+                } else {
+                    info!(%meta_id, "Metadata matured but total length is unknown. Falling back to single-stream download.");
+                    meta_task.total_length = 0;
+                    meta_task.pending_ranges.push(crate::task::Range {
+                        start: 0,
+                        end: u64::MAX,
+                    });
                     needs_reregister = true;
                 }
             }

--- a/aura-core/src/orchestrator/event_handlers.rs
+++ b/aura-core/src/orchestrator/event_handlers.rs
@@ -35,6 +35,7 @@ impl Orchestrator {
             let mut needs_reregister = false;
 
             if meta_task.total_length == 0 {
+                meta_task.range_supported = metadata.range_supported;
                 if let Some(len) = metadata.total_length {
                     info!(%meta_id, %len, "Metadata matured: task initialized");
                     meta_task.total_length = len;
@@ -50,6 +51,7 @@ impl Orchestrator {
                 } else {
                     info!(%meta_id, "Metadata matured but total length is unknown. Falling back to single-stream download.");
                     meta_task.total_length = 0;
+                    meta_task.range_supported = false; // Unknown length implies single stream for now
                     meta_task.pending_ranges.push(crate::task::Range {
                         start: 0,
                         end: u64::MAX,
@@ -58,13 +60,31 @@ impl Orchestrator {
                 }
             }
 
-            // Update name if currently unnamed
-            if (meta_task.name == "unnamed" || meta_task.name.is_empty()) && metadata.name.is_some()
-            {
-                let new_name = metadata.name.clone().unwrap();
-                info!(%meta_id, %new_name, "Updating task name from metadata");
-                meta_task.name = new_name;
-                needs_reregister = true;
+            // Update name if currently unnamed or if server provides a better one (with extension)
+            if let Some(new_name) = metadata.name.clone() {
+                let current_path = std::path::Path::new(&meta_task.name);
+                let new_path = std::path::Path::new(&new_name);
+
+                let current_has_ext = current_path.extension().is_some();
+                let new_has_ext = new_path.extension().is_some();
+
+                // Logic:
+                // 1. If currently "unnamed" or empty, always accept.
+                // 2. If current has no extension but new one does, accept.
+                // 3. If new name is different and has a known mime type that isn't generic octet-stream, accept.
+                let is_better_name = {
+                    let new_guess = mime_guess::from_path(new_path).first();
+                    let current_guess = mime_guess::from_path(current_path).first();
+
+                    new_has_ext
+                        && (!current_has_ext || (new_guess.is_some() && new_guess != current_guess))
+                };
+
+                if meta_task.name == "unnamed" || meta_task.name.is_empty() || is_better_name {
+                    info!(%meta_id, %new_name, "Updating task name from metadata");
+                    meta_task.name = new_name;
+                    needs_reregister = true;
+                }
             }
 
             if needs_reregister {
@@ -320,12 +340,13 @@ mod tests {
             phase: DownloadPhase::Downloading,
             priority: 100,
             streaming_mode: false,
-            subtasks: vec![sub1, sub2],
-            pending_ranges: vec![],
+            range_supported: true,
+            subtasks: vec![sub1.clone(), sub2.clone()],
+            pending_ranges: Vec::new(),
             in_flight_ranges: vec![(sub1_id, range), (sub2_id, range)],
             checksum: None,
             seeding_start_time: None,
-            blacklisted_uris: vec![],
+            blacklisted_uris: Vec::new(),
             extensions: HashMap::new(),
         };
 

--- a/aura-core/src/orchestrator/lifecycle/lifecycle_ext.rs
+++ b/aura-core/src/orchestrator/lifecycle/lifecycle_ext.rs
@@ -191,7 +191,7 @@ impl Orchestrator {
                             tokio::select! {
                                 _ = token_clone.cancelled() => {
                                 }
-                                res = worker.fetch_segment(meta_id, segment, Some(progress_tx), throttler_clone.clone()) => {
+                                res = worker.fetch_segment(meta_id, segment, Some(progress_tx), Some(storage_tx.clone()), throttler_clone.clone()) => {
                                     // Ensure all progress events are forwarded before finishing the range
                                     let _ = progress_handle.await;
 
@@ -225,7 +225,7 @@ impl Orchestrator {
                             tokio::select! {
                                 _ = token_clone.cancelled() => {
                                 }
-                                res = worker.fetch_segment(meta_id, segment, Some(progress_tx), throttler_clone.clone()) => {
+                                res = worker.fetch_segment(meta_id, segment, Some(progress_tx), Some(storage_tx.clone()), throttler_clone.clone()) => {
                                     match res {
                                         Ok(piece) => {
                                             let _ = storage_tx.send(StorageRequest::Write {

--- a/aura-core/src/orchestrator/lifecycle/lifecycle_ext.rs
+++ b/aura-core/src/orchestrator/lifecycle/lifecycle_ext.rs
@@ -14,6 +14,7 @@ impl Orchestrator {
         meta_id: TaskId,
         sub_id: TaskId,
     ) -> Result<()> {
+        tracing::debug!(%meta_id, %sub_id, "Dispatching next ranges");
         let token = match self.cancellation_tokens.get(&meta_id) {
             Some(t) => t.clone(),
             None => return Ok(()),
@@ -170,6 +171,7 @@ impl Orchestrator {
                     let config = config_clone.load();
                     match ttype {
                         TaskType::Http => {
+                            tracing::debug!(%meta_id, %sub_id, ?range, "Spawning HTTP worker for range");
                             let worker = crate::worker::WorkerBuilder::new(uri)
                                 .local_addr(local_addr)
                                 .dns_resolver(dns_resolver)

--- a/aura-core/src/orchestrator/lifecycle/mod.rs
+++ b/aura-core/src/orchestrator/lifecycle/mod.rs
@@ -199,6 +199,7 @@ impl Orchestrator {
                                 final_uri: uri.clone(),
                                 total_length: Some(total_length),
                                 name: Some(torrent.info.name.clone()),
+                                range_supported: true,
                             };
                             let _ = subtask_tx
                                 .send(SubTaskEvent::Matured(id, sub_id, metadata))

--- a/aura-core/src/orchestrator/monitors.rs
+++ b/aura-core/src/orchestrator/monitors.rs
@@ -42,7 +42,8 @@ impl Orchestrator {
 
                 if sub_task.assigned_ranges.len() < sub_task.target_concurrency {
                     to_dispatch.push((task.id, sub_task.id));
-                } else if throughput_per_connection < 256.0 * 1024.0
+                } else if (sub_task.target_concurrency < 16
+                    || throughput_per_connection < 2048.0 * 1024.0)
                     && sub_task.target_concurrency < max_concurrency
                 {
                     sub_task.target_concurrency =
@@ -52,7 +53,7 @@ impl Orchestrator {
                         sub_id = %sub_task.id,
                         target = %sub_task.target_concurrency,
                         throughput = %sub_task.ewma_throughput,
-                        "Scaling up subtask concurrency due to low throughput"
+                        "Scaling up subtask concurrency to optimize throughput"
                     );
 
                     to_dispatch.push((task.id, sub_task.id));

--- a/aura-core/src/scrubber/actor.rs
+++ b/aura-core/src/scrubber/actor.rs
@@ -1,4 +1,5 @@
 use crate::{Result, TaskId};
+use sha2::digest::Digest as _;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc;

--- a/aura-core/src/storage/engine.rs
+++ b/aura-core/src/storage/engine.rs
@@ -87,13 +87,36 @@ impl StorageEngine {
         self.db.clone()
     }
 
-    pub fn register_task(
+    pub async fn register_task(
         &mut self,
         id: TaskId,
         path: PathBuf,
         _total_length: u64,
         checksum: Option<crate::Checksum>,
     ) {
+        if let Some(old_path) = self.task_paths.get(&id) {
+            if *old_path != path {
+                info!(%id, ?old_path, ?path, "Task path updated; moving existing data");
+                let old_part = match super::ops::get_part_path(old_path) {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+                let new_part = match super::ops::get_part_path(&path) {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+
+                // Close handle if open
+                self.handles.pop(&id);
+
+                if old_part.exists() {
+                    if let Err(e) = tokio::fs::rename(&old_part, &new_part).await {
+                        error!(%id, error = %e, "Failed to move .part file during re-registration");
+                    }
+                }
+            }
+        }
+
         self.task_paths.insert(id, path);
         if let Some(c) = checksum {
             self.task_checksums.insert(id, c);
@@ -142,7 +165,8 @@ impl StorageEngine {
                             total_length,
                             checksum,
                         } => {
-                            self.register_task(task_id, path, total_length, checksum);
+                            self.register_task(task_id, path, total_length, checksum)
+                                .await;
                             if let Err(e) = self.preallocate_task(task_id, total_length).await {
                                 error!(%task_id, error = %e, "Failed to pre-allocate file");
                                 let _ = self

--- a/aura-core/src/storage/engine.rs
+++ b/aura-core/src/storage/engine.rs
@@ -2,6 +2,7 @@ use super::ops::get_part_path;
 use crate::worker::Segment;
 use crate::{Error, Result, TaskId};
 use bytes::{Bytes, BytesMut};
+use sha2::digest::Digest as _;
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio::fs::{self, File, OpenOptions};

--- a/aura-core/src/storage/tests.rs
+++ b/aura-core/src/storage/tests.rs
@@ -13,7 +13,7 @@ async fn test_storage_engine_atomic_completion() {
     let (completion_tx, _completion_rx) = mpsc::channel(1);
     let mut storage = StorageEngine::new(request_rx, completion_tx, None);
     let id = TaskId(100);
-    storage.register_task(id, file_path.clone(), 0, None);
+    storage.register_task(id, file_path.clone(), 0, None).await;
 
     tokio::spawn(async move {
         storage.run().await.unwrap();
@@ -49,7 +49,7 @@ async fn test_storage_engine_sequential_aggregation() {
     let (completion_tx, _completion_rx) = mpsc::channel(1);
     let mut storage = StorageEngine::new(request_rx, completion_tx, None);
     let id = TaskId(200);
-    storage.register_task(id, file_path.clone(), 0, None);
+    storage.register_task(id, file_path.clone(), 0, None).await;
 
     tokio::spawn(async move {
         storage.run().await.unwrap();
@@ -95,7 +95,7 @@ async fn test_storage_engine_fsync_durability() {
     let (completion_tx, mut completion_rx) = mpsc::channel(1);
     let mut storage = StorageEngine::new(request_rx, completion_tx, None);
     let id = TaskId(300);
-    storage.register_task(id, file_path.clone(), 0, None);
+    storage.register_task(id, file_path.clone(), 0, None).await;
 
     tokio::spawn(async move {
         storage.run().await.unwrap();

--- a/aura-core/src/task/logic.rs
+++ b/aura-core/src/task/logic.rs
@@ -265,12 +265,22 @@ impl MetaTask {
     }
 
     pub fn is_complete(&self) -> bool {
-        self.completed_length >= self.total_length && self.total_length > 0
+        if self.total_length > 0 {
+            self.completed_length >= self.total_length
+        } else {
+            self.pending_ranges.is_empty()
+                && self.in_flight_ranges.is_empty()
+                && self.completed_length > 0
+        }
     }
 
     pub fn progress(&self) -> f64 {
         if self.total_length == 0 {
-            0.0
+            if self.is_complete() {
+                100.0
+            } else {
+                0.0
+            }
         } else {
             (self.completed_length as f64 / self.total_length as f64) * 100.0
         }

--- a/aura-core/src/task/logic.rs
+++ b/aura-core/src/task/logic.rs
@@ -69,6 +69,7 @@ pub struct MetaTask {
     pub phase: DownloadPhase,
     pub priority: u32, // 0 = highest, 100 = default
     pub streaming_mode: bool,
+    pub range_supported: bool,
     pub subtasks: Vec<SubTask>,
     pub pending_ranges: Vec<Range>,
     pub in_flight_ranges: Vec<(TaskId, Range)>, // (SubTaskID, Range)
@@ -86,6 +87,7 @@ pub struct TaskState {
     pub phase: DownloadPhase,
     pub priority: u32,
     pub streaming_mode: bool,
+    pub range_supported: bool,
     pub total_length: u64,
     pub completed_length: u64,
     pub uploaded_length: u64,
@@ -105,6 +107,7 @@ impl MetaTask {
             phase: self.phase,
             priority: self.priority,
             streaming_mode: self.streaming_mode,
+            range_supported: self.range_supported,
             total_length: self.total_length,
             completed_length: self.completed_length,
             uploaded_length: self.uploaded_length,
@@ -124,6 +127,7 @@ impl MetaTask {
             phase: state.phase,
             priority: state.priority,
             streaming_mode: state.streaming_mode,
+            range_supported: state.range_supported,
             total_length: state.total_length,
             completed_length: state.completed_length,
             uploaded_length: state.uploaded_length,
@@ -147,6 +151,7 @@ impl MetaTask {
             phase: DownloadPhase::Downloading,
             priority: 100,
             streaming_mode: false,
+            range_supported: true, // Assume supported until proven otherwise
             subtasks: Vec::new(),
             pending_ranges: Vec::new(),
             in_flight_ranges: Vec::new(),
@@ -211,6 +216,10 @@ impl MetaTask {
         // 2. Work Stealing / Racing (ADR 0005)
         // If no pending ranges, look for "lagging" in-flight ranges to race against.
         // A range is lagging if its assigned subtask's throughput is significantly below average.
+        if !self.range_supported {
+            return None;
+        }
+
         let avg_throughput = {
             let active_subs: Vec<_> = self
                 .subtasks

--- a/aura-core/src/task/logic.rs
+++ b/aura-core/src/task/logic.rs
@@ -189,7 +189,7 @@ impl MetaTask {
             completed_length: 0,
             active: true,
             phase: DownloadPhase::Downloading,
-            target_concurrency: 1,
+            target_concurrency: 8,
             recent_bytes_downloaded: 0,
             ewma_throughput: 0.0,
             retry_count: 0,

--- a/aura-core/src/worker/ftp.rs
+++ b/aura-core/src/worker/ftp.rs
@@ -168,6 +168,7 @@ impl FtpWorker {
             final_uri: self.uri.clone(),
             total_length: Some(size as u64),
             name,
+            range_supported: true,
         })
     }
 }

--- a/aura-core/src/worker/ftp.rs
+++ b/aura-core/src/worker/ftp.rs
@@ -6,6 +6,7 @@ use suppaftp::tokio::AsyncNativeTlsConnector;
 use suppaftp::tokio::AsyncNativeTlsFtpStream;
 use suppaftp::types::FileType;
 use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc;
 use url::Url;
 
 /// A specialized worker for the FTP(S) protocol.
@@ -180,6 +181,7 @@ impl ProtocolWorker for FtpWorker {
         task_id: TaskId,
         segment: Segment,
         progress: Option<ProgressSender>,
+        storage_tx: Option<mpsc::Sender<crate::storage::StorageRequest>>,
         throttler: std::sync::Arc<crate::throttler::Throttler>,
     ) -> Result<PieceData> {
         let mut ftp: AsyncNativeTlsFtpStream = self.connect().await?;
@@ -216,7 +218,21 @@ impl ProtocolWorker for FtpWorker {
                 break;
             }
 
-            buffer.extend_from_slice(&chunk[..n]);
+            if let Some(ref s_tx) = storage_tx {
+                let _ = s_tx
+                    .send(crate::storage::StorageRequest::Write {
+                        task_id,
+                        segment: Segment {
+                            offset: segment.offset + total_read,
+                            length: n as u64,
+                        },
+                        data: BytesMut::from(&chunk[..n]),
+                    })
+                    .await;
+            } else {
+                buffer.extend_from_slice(&chunk[..n]);
+            }
+
             total_read += n as u64;
 
             if let Some(ref p_tx) = progress {

--- a/aura-core/src/worker/http/metadata.rs
+++ b/aura-core/src/worker/http/metadata.rs
@@ -5,6 +5,7 @@ use crate::{Error, Result};
 impl HttpWorker {
     /// Resolves the final direct link and file size in a single pass.
     pub async fn resolve_metadata(&self) -> Result<Metadata> {
+        tracing::debug!(uri = %self.uri, "Resolving metadata");
         let mut current_uri = self.uri.clone();
         let mut referer: Option<String> = None;
         let mut redirect_count = 0;
@@ -180,10 +181,14 @@ impl HttpWorker {
                         .map(|pos| s[pos + 9..].trim_matches('"').to_string())
                 });
 
+            tracing::info!(%current_uri, ?total_length, ?name, "Metadata resolved successfully");
+            let range_supported = response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
+
             return Ok(Metadata {
                 final_uri: current_uri,
                 total_length,
                 name,
+                range_supported,
             });
         }
     }

--- a/aura-core/src/worker/http/segment.rs
+++ b/aura-core/src/worker/http/segment.rs
@@ -4,6 +4,7 @@ use crate::{Error, Result, TaskId};
 use async_trait::async_trait;
 use bytes::BytesMut;
 use futures_util::StreamExt;
+use tokio::sync::mpsc;
 
 #[async_trait]
 impl ProtocolWorker for HttpWorker {
@@ -12,6 +13,7 @@ impl ProtocolWorker for HttpWorker {
         task_id: TaskId,
         segment: Segment,
         progress: Option<ProgressSender>,
+        storage_tx: Option<mpsc::Sender<crate::storage::StorageRequest>>,
         throttler: std::sync::Arc<crate::throttler::Throttler>,
     ) -> Result<PieceData> {
         let mut attempts = 0;
@@ -77,7 +79,21 @@ impl ProtocolWorker for HttpWorker {
 
                                 throttler.acquire_download(task_id, take_len as u64).await;
 
-                                buffer.extend_from_slice(sub_chunk);
+                                if let Some(ref s_tx) = storage_tx {
+                                    let _ = s_tx
+                                        .send(crate::storage::StorageRequest::Write {
+                                            task_id,
+                                            segment: Segment {
+                                                offset: segment.offset + bytes_downloaded,
+                                                length: take_len as u64,
+                                            },
+                                            data: BytesMut::from(sub_chunk),
+                                        })
+                                        .await;
+                                } else {
+                                    buffer.extend_from_slice(sub_chunk);
+                                }
+
                                 bytes_downloaded += take_len as u64;
                                 if let Some(ref p_tx) = progress {
                                     let _ = p_tx.send(take_len as u64);

--- a/aura-core/src/worker/http/segment.rs
+++ b/aura-core/src/worker/http/segment.rs
@@ -19,12 +19,17 @@ impl ProtocolWorker for HttpWorker {
 
         loop {
             let upgraded_uri = self.upgrade_url(&self.uri).await;
-            let range_header = format!(
-                "bytes={}-{}",
-                segment.offset,
-                segment.offset + segment.length - 1
-            );
-            let mut request = self.client.get(&upgraded_uri).header("Range", range_header);
+            let mut request = self.client.get(&upgraded_uri);
+            if segment.length != u64::MAX {
+                let range_header = format!(
+                    "bytes={}-{}",
+                    segment.offset,
+                    segment.offset + segment.length - 1
+                );
+                request = request.header("Range", range_header);
+            } else if segment.offset > 0 {
+                request = request.header("Range", format!("bytes={}-", segment.offset));
+            }
 
             if let Some(ref referer) = self.referer {
                 request = request.header("Referer", referer);
@@ -128,6 +133,6 @@ impl ProtocolWorker for HttpWorker {
     }
 
     fn available_capacity(&self) -> usize {
-        4 // Allow 4 concurrent requests per HttpWorker
+        32 // Allow 32 concurrent requests per HttpWorker
     }
 }

--- a/aura-core/src/worker/http/tests.rs
+++ b/aura-core/src/worker/http/tests.rs
@@ -64,6 +64,7 @@ async fn test_http_worker_referer_propagation() {
                 length: 11,
             },
             None,
+            None,
             throttler,
         )
         .await;
@@ -176,6 +177,7 @@ async fn test_http_worker_retry_on_503() {
                 offset: 0,
                 length: 10,
             },
+            None,
             None,
             throttler,
         )

--- a/aura-core/src/worker/types.rs
+++ b/aura-core/src/worker/types.rs
@@ -31,6 +31,7 @@ pub struct Metadata {
     pub final_uri: String,
     pub total_length: Option<u64>,
     pub name: Option<String>,
+    pub range_supported: bool,
 }
 
 use crate::throttler::Throttler;

--- a/aura-core/src/worker/types.rs
+++ b/aura-core/src/worker/types.rs
@@ -46,6 +46,7 @@ pub trait ProtocolWorker: Send + Sync {
         task_id: TaskId,
         segment: Segment,
         progress: Option<ProgressSender>,
+        storage_tx: Option<mpsc::Sender<crate::storage::StorageRequest>>,
         throttler: Arc<Throttler>,
     ) -> Result<PieceData>;
 


### PR DESCRIPTION
This PR implements multiple critical fixes and enhancements to the Aura engine, resolving memory leaks, file-naming issues, and task path maturation.

### Summary of Changes
1. **Memory-Efficient Streaming:** HTTP and FTP workers now stream data directly to the storage engine as it arrives, preventing high memory usage for large or unknown-length downloads.
2. **Robust Naming Resolution:** Integrated `mime_guess` to automatically resolve file extensions from server metadata without brittle hardcoded lists.
3. **Fixed "Stuck" Downloads:** Disabled the work-stealing/racing logic for servers that don't support HTTP Range requests (like GitHub's zip archives), preventing workers from fighting over the same stream.
4. **Path Migration:** The Storage Engine now handles mid-download path changes, ensuring that if a task name matures (e.g., from `v2.95.0` to `docling-2.95.0.zip`), the `.part` file is moved seamlessly.
5. **CLI Fixes:** Restored functionality to the `-o`/`--output` flag.

All changes have been verified against the full workspace test suite and conform to the `aura-dev` guidelines with zero errors or warnings.