### PR TITLE
fix: wire read_ahead_kb, write_buffer_kb, and min_connections_per_task config keys

### DIFF
--- a/Aura.example.toml
+++ b/Aura.example.toml
@@ -35,6 +35,8 @@ per_task_download_limit = 0            # Speed cap per individual download task
 per_task_upload_limit = 0              # Upload cap per individual download task
 max_concurrent_downloads = 5           # Max active downloads (queued tasks stay in 'Waiting')
 max_active_tasks = 100                 # Total tasks allowed in the engine (active + paused)
+min_connections_per_task = 16          # Minimum connections per individual task (adaptive scaling floor)
+max_connections_per_task = 128         # Maximum connections per individual task (adaptive scaling ceiling)
 
 [bittorrent]
 enabled = true                         # Global BitTorrent protocol toggle

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Aura 🌌
+# Aura
 
 [![CI](https://github.com/ronmkr/aura/actions/workflows/ci.yml/badge.svg)](https://github.com/ronmkr/aura/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **Aura** is a high-performance, asynchronous download engine written in Rust. It is the spiritual successor to `aria2`, reimagined for the modern era with an actor-based architecture, protocol-agnostic orchestration, and memory-safe concurrency.
 
-## 🚀 Features
+## Features
 
 - **Actor-based Orchestration**: Built on Tokio for massive concurrency and clean decoupling between protocols and storage.
 - **Multi-source Aggregation**: Download a single file from multiple sources (HTTP, BitTorrent, FTP) simultaneously with **Adaptive Racing** and **Work Stealing** (ADR 0005).
@@ -43,13 +43,26 @@ docker run --rm \
 
 ### Native Binary
 
-## 📖 Documentation
+If the `aura` binary is in your `PATH` (or using the compiled binary `./target/release/aura` directly):
+
+```bash
+# Run the interactive TUI dashboard
+./target/release/aura tui
+
+# Run the headless background daemon
+./target/release/aura daemon
+
+# Download a file using the CLI
+./target/release/aura "https://example.com/file.zip"
+```
+
+## Documentation
 
 - **[Aura User Manual](aura-docs/manual/src/introduction.md)**: The comprehensive guide to using Aura, covering CLI, TUI, and advanced features.
 - **[Architecture Deep Dive](aura-docs/project/ARCHITECTURE.md)**: Detailed mapping of our actor model and data flows.
 - **[ADR Index](aura-docs/manual/src/advanced/adr-index.md)**: The "why" behind our technical decisions.
 
-## 🛠️ Getting Started
+## Getting Started
 
 ### Installation
 Ensure you have Rust and Cargo installed, then clone the repository:
@@ -76,7 +89,7 @@ Batch download using globbing:
 ./target/release/aura "https://example.com/images/img_[001-100].jpg"
 ```
 
-## 🏗️ Architecture
+## Architecture
 
 Aura is built on a foundation of independent actors:
 1. **Orchestrator**: The "brain" that manages task lifecycles, assigns work to workers, and handles global throttling.
@@ -85,14 +98,21 @@ Aura is built on a foundation of independent actors:
 
 See [ARCHITECTURE.md](aura-docs/project/ARCHITECTURE.md) for a deep dive into the system design and [CONTEXT.md](aura-docs/project/CONTEXT.md) for our ubiquitous language.
 
-## 🤝 Contributing
+## Configuration
+
+Aura uses an optional TOML configuration file (e.g., `Aura.toml`) to tune performance:
+
+* **Storage Engine Tuning**:
+  * `read_ahead_kb`: Configures the seeding read-ahead buffer capacity for BitTorrent upload paths (defaults to `128KB`).
+  * `write_buffer_kb`: Configures the sequential flush aggregator threshold for out-of-order write buffering (defaults to `4MB`).
+* **Adaptive Scaling**:
+  * `min_connections_per_task` / `max_connections_per_task`: Controls the bounds for the adaptive concurrency scaler in the Orchestrator.
+
+See [Aura.example.toml](Aura.example.toml) for a fully annotated list of all options and their defaults.
+
+## Contributing
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for our engineering standards and TDD workflow.
 
-## 📜 License
-This project is licensed under the MIT License - see the LICENSE file for details.
-
-sues). This serves as the project's single source of truth.
-
-## 📜 License
+## License
 This project is licensed under the MIT License - see the LICENSE file for details.
 

--- a/aura-core/benches/storage_bench.rs
+++ b/aura-core/benches/storage_bench.rs
@@ -14,7 +14,7 @@ fn bench_storage_sequential_write(c: &mut Criterion) {
 
     let (request_tx, request_rx) = mpsc::channel(100);
     let (completion_tx, _completion_rx) = mpsc::channel(100);
-    let mut storage = StorageEngine::new(request_rx, completion_tx, None);
+    let mut storage = StorageEngine::new(request_rx, completion_tx, None, None);
     let id = TaskId(1);
     rt.block_on(storage.register_task(id, file_path, 0, None));
 
@@ -51,7 +51,7 @@ fn bench_storage_random_write_aggregated(c: &mut Criterion) {
 
     let (request_tx, request_rx) = mpsc::channel(1000);
     let (completion_tx, _completion_rx) = mpsc::channel(1000);
-    let mut storage = StorageEngine::new(request_rx, completion_tx, None);
+    let mut storage = StorageEngine::new(request_rx, completion_tx, None, None);
     let id = TaskId(2);
     rt.block_on(storage.register_task(id, file_path, 0, None));
 

--- a/aura-core/src/orchestrator/engine.rs
+++ b/aura-core/src/orchestrator/engine.rs
@@ -52,7 +52,12 @@ impl Engine {
         let db_path = std::path::PathBuf::from(&initial_config.storage.download_dir)
             .join(".aura")
             .join("metadata.db");
-        let storage = StorageEngine::new(storage_rx, completion_tx, Some(db_path));
+        let storage = StorageEngine::new(
+            storage_rx,
+            completion_tx,
+            Some(db_path),
+            Some(config.clone()),
+        );
 
         let mut dht_id = [0u8; 20];
         rand::rng().fill(&mut dht_id);

--- a/aura-core/src/orchestrator/monitors.rs
+++ b/aura-core/src/orchestrator/monitors.rs
@@ -4,6 +4,10 @@ impl Orchestrator {
     pub(crate) async fn perform_adaptive_scaling(&mut self) {
         let config = self.config.load();
         let max_concurrency = config.bandwidth.max_connections_per_task;
+        let min_concurrency = config
+            .bandwidth
+            .min_connections_per_task
+            .min(max_concurrency);
 
         // EWMA factor
         let alpha = 0.3;
@@ -40,14 +44,24 @@ impl Orchestrator {
                     0.0
                 };
 
-                if sub_task.assigned_ranges.len() < sub_task.target_concurrency {
+                // Enforce minimum connections per task limit
+                if sub_task.target_concurrency < min_concurrency {
+                    sub_task.target_concurrency = min_concurrency;
+                    tracing::debug!(
+                        meta_id = %task.id,
+                        sub_id = %sub_task.id,
+                        target = %sub_task.target_concurrency,
+                        "Clamping subtask concurrency to minimum"
+                    );
+                    to_dispatch.push((task.id, sub_task.id));
+                } else if sub_task.assigned_ranges.len() < sub_task.target_concurrency {
                     to_dispatch.push((task.id, sub_task.id));
                 } else if (sub_task.target_concurrency < 16
                     || throughput_per_connection < 2048.0 * 1024.0)
                     && sub_task.target_concurrency < max_concurrency
                 {
                     sub_task.target_concurrency =
-                        (sub_task.target_concurrency + 1).min(max_concurrency);
+                        (sub_task.target_concurrency + 1).clamp(min_concurrency, max_concurrency);
                     tracing::debug!(
                         meta_id = %task.id,
                         sub_id = %sub_task.id,
@@ -65,5 +79,117 @@ impl Orchestrator {
             // Re-dispatch to spawn new workers immediately
             let _ = self.dispatch_next_ranges(meta_id, sub_id).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::orchestrator::Orchestrator;
+    use crate::task::{DownloadPhase, MetaTask, SubTask};
+    use crate::{Config, TaskId};
+    use arc_swap::ArcSwap;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_adaptive_scaling_min_connections() {
+        let (_command_tx, command_rx) = tokio::sync::mpsc::channel(10);
+        let (storage_tx, _storage_rx) = tokio::sync::mpsc::channel(10);
+        let (_storage_completion_tx, storage_completion_rx) = tokio::sync::mpsc::channel(10);
+        let (subtask_tx, subtask_rx) = tokio::sync::mpsc::channel(10);
+        let (dht_tx, _dht_rx) = tokio::sync::mpsc::channel(10);
+        let (lpd_tx, _lpd_rx) = tokio::sync::mpsc::channel(10);
+        let (scrub_tx, _scrub_rx) = tokio::sync::mpsc::channel(10);
+        let (nat_tx, _nat_rx) = tokio::sync::mpsc::channel(10);
+
+        let mut config = Config::default();
+        config.bandwidth.max_connections_per_task = 32;
+        config.bandwidth.min_connections_per_task = 12; // Test threshold
+
+        let config_swap = Arc::new(ArcSwap::from_pointee(config));
+
+        let resolver_config = crate::config::ResolverConfig::default();
+        let dns_resolver = Arc::new(
+            crate::net_util::create_resolver(&resolver_config)
+                .await
+                .unwrap(),
+        );
+
+        let mut orchestrator = Orchestrator {
+            tasks: std::collections::HashMap::new(),
+            bt_registry: std::collections::HashMap::new(),
+            worker_command_txs: std::collections::HashMap::new(),
+            cancellation_tokens: std::collections::HashMap::new(),
+            worker_cancellation_tokens: std::collections::HashMap::new(),
+            command_rx,
+            event_tx: tokio::sync::broadcast::channel(10).0,
+            storage_tx,
+            storage_completion_rx,
+            subtask_tx,
+            subtask_rx,
+            dht_tx,
+            lpd_tx,
+            scrub_tx,
+            scrub_rx: None,
+            _nat_tx: nat_tx,
+            peer_id: [0u8; 20],
+            throttler: Arc::new(crate::throttler::Throttler::new(0, 0)),
+            vpn_provider: None,
+            vpn_watch_tx: tokio::sync::watch::channel(None).0,
+            config: config_swap,
+            power_manager: crate::power::PowerManager::new(),
+            _hook_service: crate::hooks::HookManager::boot(
+                tokio::sync::broadcast::channel(10).1,
+                crate::config::HookConfig::default(),
+                crate::hooks::ShellExecutor::new(),
+                crate::hooks::HookOptions::default(),
+            ),
+            credential_provider: Arc::new(crate::config::credentials::CredentialProvider::new()),
+            dns_resolver,
+            db: sled::Config::new().temporary(true).open().unwrap(),
+            hsts_cache: crate::security::HstsCache::new(),
+        };
+
+        let sub_task = SubTask {
+            id: TaskId(11),
+            uri: "http://example.com/file".to_string(),
+            task_type: crate::task::TaskType::Http,
+            phase: DownloadPhase::Downloading,
+            total_length: 1000,
+            completed_length: 0,
+            assigned_ranges: Vec::new(),
+            target_concurrency: 4, // Below min_connections_per_task
+            recent_bytes_downloaded: 100,
+            ewma_throughput: 100.0,
+            active: true,
+            retry_count: 0,
+        };
+
+        let task = MetaTask {
+            id: TaskId(1),
+            name: "test_task".to_string(),
+            phase: DownloadPhase::Downloading,
+            total_length: 1000,
+            completed_length: 0,
+            uploaded_length: 0,
+            priority: 100,
+            streaming_mode: false,
+            range_supported: true,
+            subtasks: vec![sub_task],
+            pending_ranges: Vec::new(),
+            in_flight_ranges: Vec::new(),
+            checksum: None,
+            seeding_start_time: None,
+            blacklisted_uris: Vec::new(),
+            extensions: std::collections::HashMap::new(),
+        };
+
+        orchestrator.tasks.insert(TaskId(1), task);
+
+        // Run scaling
+        orchestrator.perform_adaptive_scaling().await;
+
+        // Assert target concurrency clamped to min
+        let scaled_task = orchestrator.tasks.get(&TaskId(1)).unwrap();
+        assert_eq!(scaled_task.subtasks[0].target_concurrency, 12);
     }
 }

--- a/aura-core/src/storage/engine.rs
+++ b/aura-core/src/storage/engine.rs
@@ -4,6 +4,7 @@ use crate::{Error, Result, TaskId};
 use bytes::{Bytes, BytesMut};
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::fs::{self, File, OpenOptions};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info};
@@ -51,6 +52,7 @@ pub struct StorageEngine {
     pub(crate) next_offsets: HashMap<TaskId, u64>,
     pub(crate) db: sled::Db,
     pub(crate) scheduler: super::scheduler::IoScheduler,
+    pub(crate) config: Option<Arc<arc_swap::ArcSwap<crate::Config>>>,
 }
 
 impl StorageEngine {
@@ -58,6 +60,7 @@ impl StorageEngine {
         request_rx: mpsc::Receiver<StorageRequest>,
         completion_tx: mpsc::Sender<StorageEvent>,
         db_path: Option<PathBuf>,
+        config: Option<Arc<arc_swap::ArcSwap<crate::Config>>>,
     ) -> Self {
         let db = if let Some(path) = db_path {
             sled::open(&path).expect("Failed to open metadata database")
@@ -80,6 +83,7 @@ impl StorageEngine {
             next_offsets: HashMap::new(),
             db,
             scheduler: super::scheduler::IoScheduler::new(),
+            config,
         }
     }
 

--- a/aura-core/src/storage/ops.rs
+++ b/aura-core/src/storage/ops.rs
@@ -4,17 +4,28 @@ use crate::Error;
 use crate::{Result, TaskId};
 use bytes::{Bytes, BytesMut};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio::fs;
 use tracing::{debug, info};
 
 impl StorageEngine {
     pub(crate) async fn handle_read(&mut self, id: TaskId, segment: Segment) -> Result<Bytes> {
+        let buffer_size = self
+            .config
+            .as_ref()
+            .map(|cfg: &Arc<arc_swap::ArcSwap<crate::Config>>| {
+                cfg.load().storage.read_ahead_kb as usize * 1024
+            })
+            .unwrap_or(128 * 1024); // Default to 128 KB seeding read buffer capacity
+
         let file = self.get_or_open_part_file(id).await?;
         use tokio::io::AsyncReadExt;
         use tokio::io::AsyncSeekExt;
         file.seek(std::io::SeekFrom::Start(segment.offset)).await?;
+
+        let mut reader = tokio::io::BufReader::with_capacity(buffer_size, file);
         let mut buf = vec![0u8; segment.length as usize];
-        file.read_exact(&mut buf).await?;
+        reader.read_exact(&mut buf).await?;
         Ok(Bytes::from(buf))
     }
 
@@ -60,9 +71,17 @@ impl StorageEngine {
 
             self.next_offsets.insert(id, current_offset);
 
-            // Flush if we hit the 4MB threshold
+            // Flush if we hit the write buffer threshold
+            let threshold = self
+                .config
+                .as_ref()
+                .map(|cfg: &Arc<arc_swap::ArcSwap<crate::Config>>| {
+                    cfg.load().storage.write_buffer_kb as usize * 1024
+                })
+                .unwrap_or(4_194_304); // Default to 4MB if no config provided
+
             if let Some(&size) = self.dirty_sizes.get(&id) {
-                if size >= 4_194_304 {
+                if size >= threshold {
                     self.flush_dirty_buffer(id).await?;
                 }
             }

--- a/aura-core/src/storage/tests.rs
+++ b/aura-core/src/storage/tests.rs
@@ -11,7 +11,7 @@ async fn test_storage_engine_atomic_completion() {
     let file_path = dir.path().join("final_file.bin");
     let (request_tx, request_rx) = mpsc::channel(1);
     let (completion_tx, _completion_rx) = mpsc::channel(1);
-    let mut storage = StorageEngine::new(request_rx, completion_tx, None);
+    let mut storage = StorageEngine::new(request_rx, completion_tx, None, None);
     let id = TaskId(100);
     storage.register_task(id, file_path.clone(), 0, None).await;
 
@@ -47,7 +47,7 @@ async fn test_storage_engine_sequential_aggregation() {
 
     let (request_tx, request_rx) = mpsc::channel(10);
     let (completion_tx, _completion_rx) = mpsc::channel(1);
-    let mut storage = StorageEngine::new(request_rx, completion_tx, None);
+    let mut storage = StorageEngine::new(request_rx, completion_tx, None, None);
     let id = TaskId(200);
     storage.register_task(id, file_path.clone(), 0, None).await;
 
@@ -93,7 +93,7 @@ async fn test_storage_engine_fsync_durability() {
     let file_path = dir.path().join("durable_file.bin");
     let (request_tx, request_rx) = mpsc::channel(1);
     let (completion_tx, mut completion_rx) = mpsc::channel(1);
-    let mut storage = StorageEngine::new(request_rx, completion_tx, None);
+    let mut storage = StorageEngine::new(request_rx, completion_tx, None, None);
     let id = TaskId(300);
     storage.register_task(id, file_path.clone(), 0, None).await;
 


### PR DESCRIPTION
This PR wires up three previously dead configuration keys in the storage engine and concurrency scaler. Closes #145.