### PR TITLE
feat: respect BEP 12 tracker tier ordering and promotion (fixes #147)

### DIFF
--- a/aura-core/src/tracker/logic.rs
+++ b/aura-core/src/tracker/logic.rs
@@ -21,6 +21,8 @@ pub struct TrackerClient {
     pub(crate) local_addr: Option<std::net::IpAddr>,
     pub(crate) _user_agent: Option<String>,
     pub(crate) proxy: Option<String>,
+    pub(crate) tracker_tiers:
+        std::sync::Mutex<std::collections::HashMap<[u8; 20], Vec<Vec<String>>>>,
 }
 
 impl TrackerClient {
@@ -62,54 +64,148 @@ impl TrackerClient {
             local_addr,
             _user_agent: user_agent,
             proxy,
+            tracker_tiers: std::sync::Mutex::new(std::collections::HashMap::new()),
         }
     }
 
     pub async fn announce(&self, torrent: &Torrent) -> Result<Vec<Peer>> {
-        let mut trackers = Vec::new();
-        trackers.push(torrent.announce.clone());
-        if let Some(announce_list) = &torrent.announce_list {
-            for list in announce_list {
-                for url in list {
-                    if !trackers.contains(url) {
-                        trackers.push(url.clone());
+        let info_hash = if let Some(h2) = torrent.info_hash_v2()? {
+            let mut truncated = [0u8; 20];
+            truncated.copy_from_slice(&h2[..20]);
+            truncated
+        } else {
+            torrent
+                .info_hash_v1()?
+                .ok_or_else(|| Error::Protocol("No info hash available".to_string()))?
+        };
+
+        // 1. Get or initialize our tiers
+        let tiers = {
+            let mut map = self.tracker_tiers.lock().unwrap();
+            if let Some(cached) = map.get(&info_hash) {
+                cached.clone()
+            } else {
+                let mut seen = std::collections::HashSet::new();
+                let mut parsed_tiers: Vec<Vec<String>> = Vec::new();
+                if let Some(announce_list) = &torrent.announce_list {
+                    for tier in announce_list {
+                        let mut filtered_tier = Vec::new();
+                        for url in tier {
+                            if !url.is_empty() && seen.insert(url.clone()) {
+                                filtered_tier.push(url.clone());
+                            }
+                        }
+                        if !filtered_tier.is_empty() {
+                            parsed_tiers.push(filtered_tier);
+                        }
+                    }
+                }
+
+                if parsed_tiers.is_empty()
+                    && !torrent.announce.is_empty()
+                    && seen.insert(torrent.announce.clone())
+                {
+                    parsed_tiers.push(vec![torrent.announce.clone()]);
+                }
+
+                // Shuffle each tier (BEP 12)
+                use rand::seq::SliceRandom;
+                let mut rng = rand::rng();
+                for tier in &mut parsed_tiers {
+                    tier.shuffle(&mut rng);
+                }
+
+                map.insert(info_hash, parsed_tiers.clone());
+                parsed_tiers
+            }
+        };
+
+        if tiers.is_empty() {
+            return Err(Error::Protocol("No tracker URLs available".to_string()));
+        }
+
+        let mut all_peers = Vec::new();
+        let mut overall_success = false;
+
+        // Keep track of which trackers succeeded per tier to promote them later
+        let mut successful_trackers_by_tier = Vec::new();
+
+        for tier in &tiers {
+            if tier.is_empty() {
+                successful_trackers_by_tier.push(Vec::new());
+                continue;
+            }
+
+            // Contact all trackers within this tier in parallel (BEP 12)
+            let mut futures = Vec::new();
+            for url in tier {
+                futures.push(self.announce_single(url.clone(), torrent));
+            }
+
+            let results = join_all(futures).await;
+            let mut tier_successful_urls = Vec::new();
+            let mut tier_success = false;
+
+            for (i, res) in results.into_iter().enumerate() {
+                let url = &tier[i];
+                match res {
+                    Ok(peers) => {
+                        tracing::info!(url = %url, count = peers.len(), "Tracker returned peers");
+                        all_peers.extend(peers);
+                        tier_successful_urls.push(url.clone());
+                        tier_success = true;
+                        overall_success = true;
+                    }
+                    Err(e) => {
+                        tracing::debug!(url = %url, error = %e, "Tracker announce failed");
                     }
                 }
             }
-        }
 
-        let mut futures = Vec::new();
-        for url in &trackers {
-            futures.push(self.announce_single(url.clone(), torrent));
-        }
+            successful_trackers_by_tier.push(tier_successful_urls);
 
-        let results = join_all(futures).await;
-        let mut all_peers = Vec::new();
-        let mut success = false;
-
-        for (i, res) in results.into_iter().enumerate() {
-            let url = &trackers[i];
-            match res {
-                Ok(peers) => {
-                    tracing::info!(url = %url, count = peers.len(), "Tracker returned peers");
-                    all_peers.extend(peers);
-                    success = true;
-                }
-                Err(e) => {
-                    tracing::debug!(url = %url, error = %e, "Tracker announce failed");
-                }
+            // BEP 12: If we successfully connected to a tracker in this tier,
+            // we stop and do not try subsequent tiers.
+            if tier_success {
+                break;
             }
         }
 
-        if success {
+        if overall_success {
+            // Update the tier order: move successful trackers to the front of their tier (BEP 12)
+            let mut map = self.tracker_tiers.lock().unwrap();
+            if let Some(cached_tiers) = map.get_mut(&info_hash) {
+                for (tier_idx, successful_urls) in
+                    successful_trackers_by_tier.into_iter().enumerate()
+                {
+                    if tier_idx < cached_tiers.len() && !successful_urls.is_empty() {
+                        let tier = &mut cached_tiers[tier_idx];
+                        let mut new_tier = Vec::with_capacity(tier.len());
+                        // Add successful ones
+                        for url in &successful_urls {
+                            if tier.contains(url) {
+                                new_tier.push(url.clone());
+                            }
+                        }
+                        // Add others
+                        for url in tier.iter() {
+                            if !successful_urls.contains(url) {
+                                new_tier.push(url.clone());
+                            }
+                        }
+                        *tier = new_tier;
+                    }
+                }
+            }
+
             tracing::info!(
                 total = all_peers.len(),
-                "Discovered peers from all trackers"
+                "Discovered peers from successful tracker tier(s)"
             );
             Ok(all_peers)
         } else {
             Err(Error::Protocol(
-                "All tracker announcements failed".to_string(),
+                "All tracker announcements failed across all tiers".to_string(),
             ))
         }
     }

--- a/aura-core/src/tracker/tests.rs
+++ b/aura-core/src/tracker/tests.rs
@@ -30,3 +30,140 @@ fn test_parse_non_compact_peers() {
     assert_eq!(peers[0].ip, "127.0.0.1");
     assert_eq!(peers[0].port, 6881);
 }
+
+#[tokio::test]
+async fn test_bep12_tracker_tiers() {
+    // Start mock servers representing trackers
+    let server_a = wiremock::MockServer::start().await; // Tier 0 - Tracker A (always succeeds)
+    let server_b = wiremock::MockServer::start().await; // Tier 0 - Tracker B (always fails)
+    let server_c = wiremock::MockServer::start().await; // Tier 1 - Tracker C (succeeds)
+
+    // Set up mock responders
+    // Server A: succeeds
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_bytes(b"d5:peers0:e".to_vec()))
+        .mount(&server_a)
+        .await;
+
+    // Server B: fails (500)
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(500))
+        .mount(&server_b)
+        .await;
+
+    // Server C: succeeds
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_bytes(b"d5:peers0:e".to_vec()))
+        .mount(&server_c)
+        .await;
+
+    let client = TrackerClient::new([0; 20], 6881, None, None, None);
+
+    // 1. First scenario: Announce list = [[ServerB (fails)], [ServerC (succeeds)]]
+    // The client should try Tier 0 (Server B) -> fails.
+    // Then it should fall back to Tier 1 (Server C) -> succeeds.
+    let torrent1 = crate::torrent::Torrent {
+        announce: "http://example.com/announce".to_string(),
+        info: crate::torrent::Info {
+            name: "test1".to_string(),
+            piece_length: 262144,
+            pieces: Some(vec![0; 20]),
+            length: Some(1024),
+            files: None,
+            meta_version: None,
+            file_tree: None,
+        },
+        announce_list: Some(vec![vec![server_b.uri()], vec![server_c.uri()]]),
+        comment: None,
+        created_by: None,
+        creation_date: None,
+        piece_layers: None,
+    };
+
+    let peers1 = client.announce(&torrent1).await.unwrap();
+    assert!(peers1.is_empty());
+
+    // 2. Second scenario: Announce list = [[ServerB (fails), ServerA (succeeds)]]
+    // Within Tier 0, Server B fails and Server A succeeds.
+    // After announce, Server A should be promoted to the front of Tier 0.
+    let torrent2 = crate::torrent::Torrent {
+        announce: "http://example.com/announce".to_string(),
+        info: crate::torrent::Info {
+            name: "test2".to_string(),
+            piece_length: 262144,
+            pieces: Some(vec![0; 20]),
+            length: Some(1024),
+            files: None,
+            meta_version: None,
+            file_tree: None,
+        },
+        announce_list: Some(vec![vec![server_b.uri(), server_a.uri()]]),
+        comment: None,
+        created_by: None,
+        creation_date: None,
+        piece_layers: None,
+    };
+
+    let hash2 = torrent2.info_hash_v1().unwrap().unwrap();
+
+    let peers2 = client.announce(&torrent2).await.unwrap();
+    assert!(peers2.is_empty());
+
+    // Check cached tiers: Server A should be moved to the front of Tier 0
+    let cached = client.tracker_tiers.lock().unwrap();
+    let tiers = cached.get(&hash2).unwrap();
+    assert_eq!(tiers.len(), 1);
+    assert_eq!(tiers[0].len(), 2);
+    assert_eq!(tiers[0][0], server_a.uri());
+    assert_eq!(tiers[0][1], server_b.uri());
+}
+
+#[tokio::test]
+async fn test_bep12_tracker_tiers_edge_cases() {
+    let client = TrackerClient::new([0; 20], 6881, None, None, None);
+
+    let torrent = crate::torrent::Torrent {
+        announce: "http://example.com/announce".to_string(),
+        info: crate::torrent::Info {
+            name: "test_edge".to_string(),
+            piece_length: 262144,
+            pieces: Some(vec![0; 20]),
+            length: Some(1024),
+            files: None,
+            meta_version: None,
+            file_tree: None,
+        },
+        announce_list: Some(vec![
+            vec![
+                "http://duplicate.com".to_string(),
+                "".to_string(),
+                "http://duplicate.com".to_string(),
+            ],
+            vec![],
+            vec![
+                "http://duplicate.com".to_string(),
+                "http://unique.com".to_string(),
+            ],
+        ]),
+        comment: None,
+        created_by: None,
+        creation_date: None,
+        piece_layers: None,
+    };
+
+    let hash = torrent.info_hash_v1().unwrap().unwrap();
+
+    // Call announce - it will fail because these URLs are fake, but it will initialize the cache!
+    let _ = client.announce(&torrent).await;
+
+    // Check cached tiers
+    let cached = client.tracker_tiers.lock().unwrap();
+    let tiers = cached.get(&hash).unwrap();
+
+    // Tiers should be:
+    // Tier 0: ["http://duplicate.com"]
+    // Tier 1: ["http://unique.com"] (since duplicate was already seen in Tier 0 and empty tier is omitted)
+    assert_eq!(tiers.len(), 2);
+    assert_eq!(tiers[0], vec!["http://duplicate.com".to_string()]);
+    assert_eq!(tiers[1], vec!["http://unique.com".to_string()]);
+}

--- a/aura-core/tests/steps/swarm.rs
+++ b/aura-core/tests/steps/swarm.rs
@@ -17,7 +17,7 @@ async fn when_add_task(world: &mut AuraWorld) {
     }
 }
 
-#[then(expr = "the Engine should enter {string} phase")]
+#[then(expr = "the engine should enter {string} phase")]
 async fn then_engine_enter_phase(world: &mut AuraWorld, _phase: String) {
     if let Some(engine) = &world.engine {
         if let Some(_id) = world.last_task_id {

--- a/aura-docs/adr/0053-bep12-tracker-tiers.md
+++ b/aura-docs/adr/0053-bep12-tracker-tiers.md
@@ -1,0 +1,18 @@
+# ADR 0053: BEP 12 Multitracker Compliance
+
+## Status
+Implemented
+
+## Context
+The current tracker client in Aura queries all trackers simultaneously. This behavior is non-compliant with BEP 12 (Multitracker Metadata Extension) and can cause unnecessary network storming/load on public trackers. We need to respect the creator's priority tiers while maintaining robust peer discovery.
+
+## Decision
+1. **Tier Sequential Processing**: Process tracker tiers sequentially. If at least one tracker in a tier responds successfully, the client stops and does not query subsequent tiers.
+2. **Parallel Within Tiers**: Contact all trackers in the active tier in parallel to maximize performance and responsiveness.
+3. **Randomization**: Shuffle URLs in each tier when the torrent is first loaded.
+4. **Promotion**: Move successful tracker URLs to the front of their tier in the internal cache for future announcement loops.
+5. **Deduplication**: Filter out duplicate tracker URLs across tiers when first parsing the torrent's announce list.
+
+## Consequences
+- **Pros**: Compliant with BEP 12 specification; prevents overwhelming trackers; respects backup tiers.
+- **Cons**: Slightly slower first-run discovery time if early tiers are unresponsive, though offset by caching successful trackers.


### PR DESCRIPTION
## Description

This pull request implements full compliance with the BitTorrent Multitracker Metadata Extension (BEP 12) for tracker announcements, resolving issue #147.

Key changes:
1. **Tier Sequential Processing**: Modified the tracker client to group trackers into priority tiers (defined in `announce-list`) and process them sequentially. If at least one announcement within a tier succeeds, it terminates the loop early, preventing query storms on backup tiers.
2. **Parallel Within Tiers**: Queries all tracker URLs within the same tier in parallel using concurrent requests.
3. **Randomization**: Shuffles URLs within each tier upon initial load to distribute query load evenly.
4. **Promotion**: Moves successful tracker URLs to the front of their respective tier in the internal cache.
5. **Deduplication Edge Case**: Deduplicates tracker URLs across all tiers and filters out empty strings/empty tiers.
6. **ADR Alignment**: Added [0053-bep12-tracker-tiers.md](file:///Users/raunak/Documents/projects/aria2/aura-docs/adr/0053-bep12-tracker-tiers.md) to document the architectural design.

Fixes #147

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
- [x] Any dependent changes have been merged and published in downstream modules
