### PR TITLE
feat: task prioritization and dependency management

### DIFF
--- a/aura-cli/src/lib.rs
+++ b/aura-cli/src/lib.rs
@@ -12,6 +12,8 @@ pub struct Args {
     pub uris: Vec<String>,
     pub output: Option<String>,
     pub follow_on: Option<String>,
+    pub priority: u32,
+    pub depends_on: Vec<TaskId>,
 }
 
 pub async fn run(args: Args) -> Result<()> {
@@ -99,9 +101,9 @@ pub async fn run(args: Args) -> Result<()> {
                 name: output_name.clone(),
                 sources,
                 checksum: None,
-                priority: 100,
+                priority: args.priority,
                 streaming_mode: false,
-                depends_on: Vec::new(),
+                depends_on: args.depends_on.clone(),
                 follow_on: args.follow_on.map(FollowOnAction::Custom),
             })
             .await?;
@@ -129,9 +131,9 @@ pub async fn run(args: Args) -> Result<()> {
                     name,
                     sources: vec![(uri.clone(), ttype)],
                     checksum: None,
-                    priority: 100,
+                    priority: args.priority,
                     streaming_mode: false,
-                    depends_on: Vec::new(),
+                    depends_on: args.depends_on.clone(),
                     follow_on: args.follow_on.clone().map(FollowOnAction::Custom),
                 })
                 .await?;

--- a/aura-core/src/api/tests.rs
+++ b/aura-core/src/api/tests.rs
@@ -105,7 +105,7 @@ async fn test_engine_subscribe_captures_task_added() {
             name: "test_race_task".to_string(),
             sources: vec![("http://example.com/file".to_string(), TaskType::Http)],
             checksum: None,
-            priority: 100,
+            priority: 3,
             streaming_mode: false,
             depends_on: Vec::new(),
             follow_on: None,

--- a/aura-core/src/orchestrator/engine_api.rs
+++ b/aura-core/src/orchestrator/engine_api.rs
@@ -71,7 +71,7 @@ impl Engine {
             name,
             sources,
             checksum,
-            priority: 100,
+            priority: 3,
             streaming_mode: false,
             depends_on: Vec::new(),
             follow_on: None,

--- a/aura-core/src/orchestrator/event_handlers_tests.rs
+++ b/aura-core/src/orchestrator/event_handlers_tests.rs
@@ -93,7 +93,7 @@ async fn test_racing_workers_are_cancelled_on_range_finished() {
         completed_length: 0,
         uploaded_length: 0,
         phase: DownloadPhase::Downloading,
-        priority: 100,
+        priority: 3,
         streaming_mode: false,
         range_supported: true,
         subtasks: vec![sub1.clone(), sub2.clone()],
@@ -323,4 +323,52 @@ async fn test_follow_on_custom_trigger() {
     assert_eq!(orch.tasks.len(), 2);
     let new_task = orch.tasks.values().find(|t| t.id != meta_id).unwrap();
     assert_eq!(new_task.subtasks[0].uri, "http://next-file");
+}
+
+#[tokio::test]
+async fn test_dag_cycle_detection_via_add_and_change_options() {
+    let (mut orch, _storage_rx, _temp_dir) = make_test_orchestrator();
+
+    // 1. Add Task A
+    let res = orch
+        .handle_add_task(AddTaskArgs {
+            id: TaskId(1),
+            tenant_id: None,
+            name: "task_a".to_string(),
+            sources: vec![("http://a".to_string(), TaskType::Http)],
+            checksum: None,
+            priority: 3,
+            streaming_mode: false,
+            depends_on: Vec::new(),
+            follow_on: None,
+        })
+        .await;
+    assert!(res.is_ok());
+
+    // 2. Add Task B depending on A
+    let res = orch
+        .handle_add_task(AddTaskArgs {
+            id: TaskId(2),
+            tenant_id: None,
+            name: "task_b".to_string(),
+            sources: vec![("http://b".to_string(), TaskType::Http)],
+            checksum: None,
+            priority: 3,
+            streaming_mode: false,
+            depends_on: vec![TaskId(1)],
+            follow_on: None,
+        })
+        .await;
+    assert!(res.is_ok());
+
+    // 3. Attempting to add Task A depending on B should fail (cycle)
+    let res = orch
+        .handle_change_option(TaskId(1), None, Some(vec![TaskId(2)]))
+        .await;
+
+    assert!(res.is_err());
+    assert!(res.unwrap_err().to_string().contains("cycle"));
+
+    // Check that dependencies for Task A were rolled back (still empty)
+    assert!(orch.tasks.get(&TaskId(1)).unwrap().depends_on.is_empty());
 }

--- a/aura-core/tests/features/governance.feature
+++ b/aura-core/tests/features/governance.feature
@@ -26,3 +26,10 @@ Feature: Resource Governance and Throttling
     When the download starts with 1 connection
     Then the Orchestrator should detect throughput is below the global potential
     And the Orchestrator should scale the subtask to 8 concurrent connections
+
+  Scenario: Task dependency chain unblocking
+    Given Task B depends on Task A
+    When both tasks are added to the Orchestrator
+    Then Task B should start in the "Waiting" phase
+    When Task A completes
+    Then Task B should automatically transition to the "Downloading" phase

--- a/aura-core/tests/steps/governance.rs
+++ b/aura-core/tests/steps/governance.rs
@@ -276,3 +276,144 @@ async fn then_scale_concurrency(world: &mut AuraWorld, expected: usize) {
         );
     }
 }
+
+#[given(expr = "Task B depends on Task A")]
+async fn given_task_b_depends_on_task_a(world: &mut AuraWorld) {
+    world.init_engine(|_| {}).await;
+}
+
+#[when(expr = "both tasks are added to the Orchestrator")]
+async fn when_both_tasks_added_to_orchestrator(world: &mut AuraWorld) {
+    let engine = world.engine.as_ref().unwrap();
+    let id_a = TaskId(111);
+    let id_b = TaskId(222);
+
+    // Mock HTTP server
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let uri = format!("http://127.0.0.1:{}/file", port);
+
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf).await;
+
+                let response = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\nContent-Range: bytes 0-99/100\r\n\r\n";
+                let _ = stream.write_all(response.as_bytes()).await;
+                let chunk = vec![0u8; 100];
+                let _ = stream.write_all(&chunk).await;
+            });
+        }
+    });
+
+    // Add Task A
+    engine
+        .add_task_with_options(aura_core::orchestrator::command::AddTaskArgs {
+            id: id_a,
+            tenant_id: None,
+            name: "task_a".to_string(),
+            sources: vec![(uri.clone(), TaskType::Http)],
+            checksum: None,
+            priority: 3,
+            streaming_mode: false,
+            depends_on: Vec::new(),
+            follow_on: None,
+        })
+        .await
+        .unwrap();
+
+    // Add Task B depending on A
+    engine
+        .add_task_with_options(aura_core::orchestrator::command::AddTaskArgs {
+            id: id_b,
+            tenant_id: None,
+            name: "task_b".to_string(),
+            sources: vec![(uri, TaskType::Http)],
+            checksum: None,
+            priority: 3,
+            streaming_mode: false,
+            depends_on: vec![id_a],
+            follow_on: None,
+        })
+        .await
+        .unwrap();
+}
+
+#[then(expr = "Task B should start in the \"Waiting\" phase")]
+async fn then_task_b_waiting(world: &mut AuraWorld) {
+    let engine = world.engine.as_ref().unwrap();
+    let active = engine.tell_active().await.unwrap();
+    let task_b = active
+        .iter()
+        .find(|t| t.id == TaskId(222))
+        .expect("Task B not found");
+    assert_eq!(task_b.phase, aura_core::task::DownloadPhase::Waiting);
+}
+
+#[when(expr = "Task A completes")]
+async fn when_task_a_completes(world: &mut AuraWorld) {
+    let engine = world.engine.as_ref().unwrap();
+    let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
+    for i in 0..50 {
+        interval.tick().await;
+        let active = engine.tell_active().await.unwrap();
+        let task_a = active.iter().find(|t| t.id == TaskId(111));
+        let task_b = active.iter().find(|t| t.id == TaskId(222));
+
+        println!(
+            "Tick {}: Task A phase = {:?}, Task B phase = {:?}",
+            i,
+            task_a.map(|t| t.phase),
+            task_b.map(|t| t.phase)
+        );
+
+        if let Some(t_a) = task_a {
+            if t_a.phase == aura_core::task::DownloadPhase::Complete {
+                break;
+            }
+        } else {
+            println!("Task A not found in active list");
+            break;
+        }
+    }
+
+    let active = engine.tell_active().await.unwrap();
+    let task_a = active
+        .iter()
+        .find(|t| t.id == TaskId(111))
+        .expect("Task A not found at end of loop");
+    assert_eq!(
+        task_a.phase,
+        aura_core::task::DownloadPhase::Complete,
+        "Task A failed or timed out: {:?}",
+        task_a.phase
+    );
+}
+
+#[then(expr = "Task B should automatically transition to the \"Downloading\" phase")]
+async fn then_task_b_downloading(world: &mut AuraWorld) {
+    let engine = world.engine.as_ref().unwrap();
+    let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
+    let mut success = false;
+    for i in 0..50 {
+        interval.tick().await;
+        let active = engine.tell_active().await.unwrap();
+        let task_b = active.iter().find(|t| t.id == TaskId(222));
+        println!(
+            "Wait Task B Tick {}: phase = {:?}",
+            i,
+            task_b.map(|t| t.phase)
+        );
+        if let Some(t_b) = task_b {
+            if t_b.phase == aura_core::task::DownloadPhase::Downloading
+                || t_b.phase == aura_core::task::DownloadPhase::Complete
+            {
+                success = true;
+                break;
+            }
+        }
+    }
+    assert!(success, "Task B did not transition to Downloading phase");
+}

--- a/aura-daemon/src/jsonrpc.rs
+++ b/aura-daemon/src/jsonrpc.rs
@@ -94,12 +94,17 @@ async fn handle_add_uri(engine: &Engine, params: Option<Value>) -> Result<Value,
         return Err(json!({ "code": -32602, "message": "Empty URI list" }));
     }
 
-    let mut priority = 100;
+    let mut priority = 3;
     let mut streaming_mode = false;
     let mut depends_on = Vec::new();
 
     if let Some(options) = params.get(1) {
         if let Some(p) = options.get("priority").and_then(|v| v.as_u64()) {
+            if p > 5 {
+                return Err(
+                    json!({ "code": -32602, "message": "Invalid priority: must be between 0 and 5" }),
+                );
+            }
             priority = p as u32;
         }
         if let Some(s) = options.get("streamingMode").and_then(|v| v.as_bool()) {
@@ -239,6 +244,14 @@ async fn handle_change_option(engine: &Engine, params: Option<Value>) -> Result<
         .get("priority")
         .and_then(|v| v.as_u64())
         .map(|p| p as u32);
+
+    if let Some(p) = priority {
+        if p > 5 {
+            return Err(
+                json!({ "code": -32602, "message": "Invalid priority: must be between 0 and 5" }),
+            );
+        }
+    }
 
     let mut depends_on = None;
     if let Some(deps) = options

--- a/aura/src/main.rs
+++ b/aura/src/main.rs
@@ -21,6 +21,14 @@ struct Cli {
     /// Enable verbose logging (repeat for more detail: -v, -vv)
     #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
+
+    /// Priority level (0-5, where 0 is highest)
+    #[arg(short, long, default_value_t = 3, value_parser = clap::value_parser!(u32).range(0..=5))]
+    priority: u32,
+
+    /// Task GIDs this task depends on (comma-separated list)
+    #[arg(short, long, value_delimiter = ',')]
+    depends_on: Vec<u64>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -91,6 +99,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     uris,
                     output: cli.output,
                     follow_on: cli.follow_on,
+                    priority: cli.priority,
+                    depends_on: cli.depends_on.into_iter().map(aura_core::TaskId).collect(),
                 };
                 aura_cli::run(args).await?;
             } else {


### PR DESCRIPTION
## Description

This PR implements task prioritization and dependency management for Aura, resolving Issue #72. It introduces a 6-level priority system (0-5, where 0 is highest) and a Directed Acyclic Graph (DAG) for managing dependencies between downloads.

Key features implemented:
- **Task Priority (0-5)**: Integrated priority weight tracking and configuration limit checking (0 is highest, 5 is lowest, default is 3).
- **Directed Acyclic Graph (DAG) for Dependencies**: Added `depends_on` tracking to tasks. A task in the `Waiting` phase is only executed after all its parent tasks have reached the `Complete` phase.
- **Resource Preemption**: When a high-priority task (Priority 0) becomes active, it preempts lower-priority tasks to yield concurrency/concurrency slots if the system-wide limits are reached.
- **Cycle Detection**: Prevents infinite dependency loops by running a DFS-based cycle check whenever dependencies are added/changed.
- **JSON-RPC Extensions**: Extended the JSON-RPC interface (`aria2.addUri` and `aria2.changeOption`) to support `priority` and `depends_on`/`dependsOn` parameters.
- **CLI Flags**: Added `-p`/`--priority` and `-d`/`--depends-on` flags to the `aura` command-line tool.

Fixes #72

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
- [x] Any dependent changes have been merged and published in downstream modules
