### PR TITLE
fix: advisory file locking for active part files

### DIFF
--- a/aura-core/src/storage/mod.rs
+++ b/aura-core/src/storage/mod.rs
@@ -11,3 +11,5 @@ pub use engine::*;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_locking;

--- a/aura-core/src/storage/ops.rs
+++ b/aura-core/src/storage/ops.rs
@@ -298,6 +298,8 @@ impl StorageEngine {
                 .open(&part_path)
                 .await?;
 
+            crate::storage::sys::try_lock_file(&file)?;
+
             if crate::storage::sys::is_network_share(&file) {
                 self.network_shares.insert(id);
             }

--- a/aura-core/src/storage/sys.rs
+++ b/aura-core/src/storage/sys.rs
@@ -205,3 +205,51 @@ pub(crate) fn apply_fadvise_sequential(file: &tokio::fs::File) {
         let _ = file;
     }
 }
+
+pub(crate) fn try_lock_file(file: &tokio::fs::File) -> crate::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+        let fd = file.as_raw_fd();
+        // SAFETY: We temporarily wrap the raw file descriptor in a standard library File
+        // to invoke try_lock. We immediately call into_raw_fd to prevent dropping the File
+        // from closing the descriptor, which is owned by the tokio wrapper.
+        unsafe {
+            let std_file = std::fs::File::from_raw_fd(fd);
+            let res = match std_file.try_lock() {
+                Ok(()) => Ok(()),
+                Err(std::fs::TryLockError::WouldBlock) => Err(crate::Error::Storage(
+                    "File is locked by another process".to_string(),
+                )),
+                Err(std::fs::TryLockError::Error(e)) => Err(crate::Error::Io(e)),
+            };
+            let _ = std_file.into_raw_fd();
+            res
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
+        let handle = file.as_raw_handle();
+        // SAFETY: We temporarily wrap the raw file handle in a standard library File
+        // to invoke try_lock. We immediately call into_raw_handle to prevent dropping the File
+        // from closing the handle, which is owned by the tokio wrapper.
+        unsafe {
+            let std_file = std::fs::File::from_raw_handle(handle);
+            let res = match std_file.try_lock() {
+                Ok(()) => Ok(()),
+                Err(std::fs::TryLockError::WouldBlock) => Err(crate::Error::Storage(
+                    "File is locked by another process".to_string(),
+                )),
+                Err(std::fs::TryLockError::Error(e)) => Err(crate::Error::Io(e)),
+            };
+            let _ = std_file.into_raw_handle();
+            res
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = file;
+        Ok(())
+    }
+}

--- a/aura-core/src/storage/tests_locking.rs
+++ b/aura-core/src/storage/tests_locking.rs
@@ -1,0 +1,71 @@
+use super::*;
+use crate::TaskId;
+use tempfile::tempdir;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn test_storage_engine_file_locking() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("locked_file.bin");
+
+    // Create channels for the storage engine
+    let (request_tx, request_rx) = mpsc::channel(10);
+    let (completion_tx, mut completion_rx) = mpsc::channel(10);
+    let storage = StorageEngine::new(request_rx, completion_tx, None, None);
+
+    tokio::spawn(async move {
+        storage.run().await.unwrap();
+    });
+
+    let id1 = TaskId(701);
+    let id2 = TaskId(702);
+
+    // Register Task 1 with non-zero length to trigger pre-allocation and locking
+    request_tx
+        .send(StorageRequest::RegisterTask {
+            task_id: id1,
+            path: file_path.clone(),
+            total_length: 100,
+            checksum: None,
+            padding_ranges: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    // Give some time for Task 1 registration to process and lock the file
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Register Task 2 using the same file. Pre-allocation should fail to lock and report an error.
+    request_tx
+        .send(StorageRequest::RegisterTask {
+            task_id: id2,
+            path: file_path.clone(),
+            total_length: 100,
+            checksum: None,
+            padding_ranges: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    // We should receive an error event for Task 2
+    let mut task2_failed = false;
+    for _ in 0..5 {
+        let event_opt =
+            tokio::time::timeout(std::time::Duration::from_millis(500), completion_rx.recv()).await;
+        if let Ok(Some(event)) = event_opt {
+            match event {
+                StorageEvent::Error(err_id, err_msg) => {
+                    if err_id == id2 {
+                        assert!(err_msg.contains("locked") || err_msg.contains("lock"));
+                        task2_failed = true;
+                        break;
+                    }
+                }
+                StorageEvent::Completed(_) => {}
+            }
+        } else {
+            break;
+        }
+    }
+    assert!(task2_failed, "Task 2 did not fail with locking error");
+}

--- a/aura-docs/adr/0021-network-filesystem-optimization.md
+++ b/aura-docs/adr/0021-network-filesystem-optimization.md
@@ -1,7 +1,7 @@
 # ADR 0021: Network Filesystem Optimization (NFS/SMB)
 
 ## Status
-Partially Implemented (Audit 2026-06-03)
+Implemented (2026-06-04)
 
 ## Context
 Downloading to network shares (NFS, SMB) presents unique challenges: high latency, potentially missing support for sparse files or `fallocate`, and risk of file corruption if multiple clients access the same share. Traditional download engines often experience performance degradation in these environments.
@@ -13,9 +13,9 @@ Downloading to network shares (NFS, SMB) presents unique challenges: high latenc
 3. **Latency Masking**: For network shares, the **Buffer Pool** will automatically increase the "flush threshold" to aggregate more data in RAM before sending it over the network.
 4. **File Locking**: We will implement advisory file locking (e.g., `flock`) to prevent multiple `Aura` instances from corrupting the same file on a shared mount.
 
-## Implementation Status (Audit 2026-06-03)
+## Implementation Status (2026-06-04)
 - **Filesystem Detection & Pre-allocation**: Fully implemented via PR #196 (2026-06-02).
-- **File Locking**: Advisory locking via `flock` or `try_lock()` on active `.part` files is pending implementation (GAP-06 / Issue #208).
+- **File Locking**: Advisory locking via cross-platform file locking (`std::fs::File::try_lock`) is fully implemented to prevent multiple Aura instances from corrupting the same file.
 
 ## Alternatives Considered
 - **Universal Lazy Allocation**: Always use lazy allocation for simplicity. *Rejected:* Local disks benefit significantly from pre-allocation (less fragmentation).

--- a/aura-docs/manual/src/advanced/adr-index.md
+++ b/aura-docs/manual/src/advanced/adr-index.md
@@ -24,7 +24,7 @@ Aura's design is driven by a series of formal Architecture Decision Records. The
 | [0018](../adr/0018-hooks-hsts-ftp.md) | ADR 0018: Hooks, HSTS, and Multi-Channel Protocols | Implemented (2026-05-06, commit 0777b1ab) |
 | [0019](../adr/0019-buffer-pool-and-caching.md) | ADR 0019: Buffer Pool and Write-Back Caching | Superceded (by Issue #160, 2026-05-30, PR #164) |
 | [0020](../adr/0020-engine-api.md) | ADR 0020: Engine API and Library Embeddability | Implemented (2026-05-06, commit 0777b1ab) |
-| [0021](../adr/0021-network-filesystem-optimization.md) | ADR 0021: Network Filesystem Optimization (NFS/SMB) | Partially Implemented (Audit 2026-06-03) |
+| [0021](../adr/0021-network-filesystem-optimization.md) | ADR 0021: Network Filesystem Optimization (NFS/SMB) | Implemented (2026-06-04) |
 | [0022](../adr/0022-disk-io-scheduling.md) | ADR 0022: Advanced Disk I/O Scheduling and Kernel Hinting | Partially Implemented (Audit 2026-06-03) |
 | [0023](../adr/0023-adaptive-scaling-and-aggregation.md) | ADR 0023: Adaptive Connection Scaling and Sourced Aggregation | Partially Implemented (2026-05-25, PR #90) |
 | [0024](../adr/0024-integrity-scrubbing.md) | ADR 0024: Integrity Scrubbing and Torrent Refreshing | Implemented (2026-05-06, commit 0777b1ab) |


### PR DESCRIPTION
## Description

This PR implements cross-platform advisory file locking for active `.part` files in the storage engine, resolving GAP-06/Issue #208 as defined in ADR 0021. This prevents multiple Aura instances from concurrently writing to the same target files and causing data corruption.

Key changes:
* Implemented cross-platform `try_lock_file` using the standard library's `std::fs::File::try_lock` by reconstructing `std::fs::File` from raw file descriptors (Unix) and raw handles (Windows) inside `sys.rs`.
* Added advisory lock verification on `.part` files immediately after they are opened in `ops.rs`.
* Added `test_storage_engine_file_locking` in a new, separate test module `tests_locking.rs` to satisfy modularity limits (keeping source/test files under 400 lines).
* Updated ADR 0021 status to `Implemented` and updated `adr-index.md` status table.

Fixes #208

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
- [x] Any dependent changes have been merged and published in downstream modules
