### PR TITLE
feat: implement DHT routing table persistence and fix clippy warnings

### DIFF
--- a/aura-core/src/config/logic_tests.rs
+++ b/aura-core/src/config/logic_tests.rs
@@ -72,7 +72,7 @@ fn test_empty_config_deserialization() {
     assert_eq!(config.bandwidth.max_concurrent_downloads, 10);
     assert_eq!(config.bittorrent.max_peers_per_torrent, 200);
     assert_eq!(config.storage.download_dir, ".".to_string());
-    assert_eq!(config.vpn.auto_connect, false);
+    assert!(!config.vpn.auto_connect);
     assert_eq!(config.general.log_level, "info".to_string());
     assert_eq!(config.general.theme.primary, "#0000FF");
 }

--- a/aura-core/src/dht/actor/mod.rs
+++ b/aura-core/src/dht/actor/mod.rs
@@ -118,8 +118,28 @@ impl DhtActor {
     pub async fn run(mut self) -> Result<()> {
         info!("DHT Actor started");
 
-        // Load persisted nodes
-        self.load_nodes().await;
+        // Resolve ~/.aura/dht.dat
+        let dht_path = {
+            let home = std::env::var_os("HOME")
+                .or_else(|| std::env::var_os("USERPROFILE"))
+                .map(std::path::PathBuf::from);
+            let mut p = match home {
+                Some(h) => h,
+                None => std::path::PathBuf::from("."),
+            };
+            p.push(".aura");
+            p.push("dht.dat");
+            p
+        };
+
+        // Load persisted nodes from file, fall back to db if it fails
+        if let Err(e) = crate::dht::PersistentState::load(&mut self, &dht_path).await {
+            debug!(
+                "Failed to load DHT state from file (falling back to database): {}",
+                e
+            );
+            self.load_nodes().await;
+        }
 
         // Bootstrap with some standard routers
         let bootstrap_nodes = vec![
@@ -162,6 +182,9 @@ impl DhtActor {
                     }
                 }
                 _ = save_interval.tick() => {
+                    if let Err(e) = crate::dht::PersistentState::save(&self, &dht_path).await {
+                        debug!("Failed to save DHT state to file: {}", e);
+                    }
                     self.save_nodes().await;
                 }
                 _ = ping_interval.tick() => {
@@ -246,5 +269,67 @@ impl DhtActor {
         for addr in nodes {
             let _ = self.send_ping(addr).await;
         }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistedNode {
+    id: [u8; 20],
+    addr: SocketAddr,
+}
+
+#[async_trait::async_trait]
+impl crate::dht::PersistentState for DhtActor {
+    async fn save(&self, path: &std::path::Path) -> crate::Result<()> {
+        let rt = self.routing_table.lock().await;
+        let mut nodes = Vec::new();
+        for bucket in &rt.buckets {
+            for node in &bucket.nodes {
+                nodes.push(PersistedNode {
+                    id: node.id,
+                    addr: node.addr,
+                });
+            }
+        }
+        drop(rt);
+
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let json = serde_json::to_string_pretty(&nodes)
+            .map_err(|e| crate::Error::Storage(format!("Failed to serialize DHT nodes: {}", e)))?;
+
+        tokio::fs::write(path, json).await?;
+        debug!(
+            ?path,
+            count = nodes.len(),
+            "Saved DHT routing table to file"
+        );
+        Ok(())
+    }
+
+    async fn load(&mut self, path: &std::path::Path) -> crate::Result<()> {
+        if !path.exists() {
+            return Ok(());
+        }
+
+        let data = tokio::fs::read(path).await?;
+        let nodes: Vec<PersistedNode> = serde_json::from_slice(&data).map_err(|e| {
+            crate::Error::Storage(format!("Failed to deserialize DHT nodes: {}", e))
+        })?;
+
+        let mut rt = self.routing_table.lock().await;
+        let count = nodes.len();
+        for p_node in nodes {
+            rt.insert(crate::dht::routing::Node {
+                id: p_node.id,
+                addr: p_node.addr,
+            });
+            // Try to ping the loaded node to verify/refresh it
+            let _ = self.send_ping(p_node.addr).await;
+        }
+        info!(?path, count, "Loaded DHT routing table from file");
+        Ok(())
     }
 }

--- a/aura-core/src/dht/mod.rs
+++ b/aura-core/src/dht/mod.rs
@@ -6,3 +6,11 @@ pub mod routing;
 mod tests;
 
 pub use actor::{DhtActor, DhtCommand};
+
+use std::path::Path;
+
+#[async_trait::async_trait]
+pub trait PersistentState {
+    async fn save(&self, path: &Path) -> crate::Result<()>;
+    async fn load(&mut self, path: &Path) -> crate::Result<()>;
+}

--- a/aura-core/src/dht/tests.rs
+++ b/aura-core/src/dht/tests.rs
@@ -62,3 +62,52 @@ async fn test_dht_rotating_tokens() {
     // Token3 should be valid as the current secret
     assert!(dht.validate_token(addr, &token3).await);
 }
+
+#[tokio::test]
+async fn test_dht_persistent_state_serialization() {
+    use crate::dht::routing::Node;
+    use crate::dht::PersistentState;
+    use tempfile::NamedTempFile;
+
+    let (_tx, _rx) = mpsc::channel(1);
+    let dht = DhtActor::new("127.0.0.1", [1; 20], _rx, None, 0, None)
+        .await
+        .unwrap();
+
+    let node_id = [2u8; 20];
+    let node_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+
+    // Insert a node into the routing table
+    {
+        let mut rt = dht.routing_table.lock().await;
+        rt.insert(Node {
+            id: node_id,
+            addr: node_addr,
+        });
+    }
+
+    // Create a temp file path
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path();
+
+    // Save state
+    dht.save(file_path).await.unwrap();
+
+    // Create a new actor and load state
+    let (_tx2, _rx2) = mpsc::channel(1);
+    let mut dht2 = DhtActor::new("127.0.0.1", [1; 20], _rx2, None, 0, None)
+        .await
+        .unwrap();
+
+    // Load state
+    dht2.load(file_path).await.unwrap();
+
+    // Verify node is present in the new routing table
+    {
+        let rt = dht2.routing_table.lock().await;
+        let closest = rt.get_closest_nodes(&node_id, 1);
+        assert_eq!(closest.len(), 1);
+        assert_eq!(closest[0].id, node_id);
+        assert_eq!(closest[0].addr, node_addr);
+    }
+}

--- a/aura-core/src/vpn/tests.rs
+++ b/aura-core/src/vpn/tests.rs
@@ -1,112 +1,109 @@
-#[cfg(test)]
-mod tests {
-    use crate::vpn::{OpenVpnProvider, VpnProvider, VpnStatus, WireGuardProvider};
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-    use tokio::net::TcpListener;
+use crate::vpn::{OpenVpnProvider, VpnProvider, VpnStatus, WireGuardProvider};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
 
-    #[tokio::test]
-    async fn test_wireguard_provider_not_found_error() {
-        // Create a provider with a dummy interface
-        let provider = WireGuardProvider::new("wg_mock_dummy".to_string());
+#[tokio::test]
+async fn test_wireguard_provider_not_found_error() {
+    // Create a provider with a dummy interface
+    let provider = WireGuardProvider::new("wg_mock_dummy".to_string());
 
-        // Attempting status, connect, or disconnect should fail elegantly with NotFound,
-        // or since "wg" command doesn't exist under standard test path or if it does,
-        // it should either work or return our custom NotFound helper error.
-        let status_res = provider.status().await;
-        // The mock provider is designed to return Disconnected on CLI error, which is safe.
-        assert_eq!(status_res.unwrap(), VpnStatus::Disconnected);
+    // Attempting status, connect, or disconnect should fail elegantly with NotFound,
+    // or since "wg" command doesn't exist under standard test path or if it does,
+    // it should either work or return our custom NotFound helper error.
+    let status_res = provider.status().await;
+    // The mock provider is designed to return Disconnected on CLI error, which is safe.
+    assert_eq!(status_res.unwrap(), VpnStatus::Disconnected);
 
-        // Connect should fail if wg-quick is not in PATH
-        let conn_res = provider.connect().await;
-        if let Err(e) = conn_res {
-            let err_msg = e.to_string();
-            assert!(
-                err_msg.contains("is not installed")
-                    || err_msg.contains("wg-quick up failed")
-                    || err_msg.contains("timed out")
-            );
-        }
+    // Connect should fail if wg-quick is not in PATH
+    let conn_res = provider.connect().await;
+    if let Err(e) = conn_res {
+        let err_msg = e.to_string();
+        assert!(
+            err_msg.contains("is not installed")
+                || err_msg.contains("wg-quick up failed")
+                || err_msg.contains("timed out")
+        );
     }
+}
 
-    #[tokio::test]
-    async fn test_openvpn_provider_handshake_and_state() {
-        // Start a mock OpenVPN management server
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let local_addr = listener.local_addr().unwrap();
+#[tokio::test]
+async fn test_openvpn_provider_handshake_and_state() {
+    // Start a mock OpenVPN management server
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_addr = listener.local_addr().unwrap();
 
-        // Spawn mock server handler
-        tokio::spawn(async move {
-            if let Ok((mut socket, _)) = listener.accept().await {
-                // 1. Send OpenVPN management greeting banner
-                let greeting = ">INFO:OpenVPN Management Interface Version 1\n";
-                socket.write_all(greeting.as_bytes()).await.unwrap();
+    // Spawn mock server handler
+    tokio::spawn(async move {
+        if let Ok((mut socket, _)) = listener.accept().await {
+            // 1. Send OpenVPN management greeting banner
+            let greeting = ">INFO:OpenVPN Management Interface Version 1\n";
+            socket.write_all(greeting.as_bytes()).await.unwrap();
 
-                // 2. Read command sent by provider
+            // 2. Read command sent by provider
+            let mut reader = BufReader::new(socket);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+
+            if line.trim() == "state" {
+                // Send response terminated by END
+                let state_response = "1622300000,CONNECTED,SUCCESS,10.8.0.6,192.0.2.1\nEND\n";
+                let mut socket = reader.into_inner();
+                socket.write_all(state_response.as_bytes()).await.unwrap();
+            }
+        }
+    });
+
+    // Instantiate OpenVpnProvider connecting to mock server
+    let provider = OpenVpnProvider::new(local_addr.to_string());
+
+    // Verify status check succeeds and parses correctly
+    let status = provider.status().await.unwrap();
+    assert_eq!(status, VpnStatus::Connected);
+}
+
+#[tokio::test]
+async fn test_openvpn_provider_password_authentication() {
+    // Start a mock OpenVPN management server requiring password
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_addr = listener.local_addr().unwrap();
+
+    // Spawn mock server handler
+    tokio::spawn(async move {
+        if let Ok((mut socket, _)) = listener.accept().await {
+            // 1. Send welcome banner and ENTER PASSWORD challenge
+            let greeting = ">INFO:OpenVPN Management Interface\nENTER PASSWORD:\n";
+            socket.write_all(greeting.as_bytes()).await.unwrap();
+
+            // 2. Read password from client
+            let mut reader = BufReader::new(socket);
+            let mut password_line = String::new();
+            reader.read_line(&mut password_line).await.unwrap();
+
+            if password_line.trim() == "my_secret_pass" {
+                // Send success response
+                let auth_success = "SUCCESS: password is correct\n>INFO: authenticated\n";
+                let mut socket = reader.into_inner();
+                socket.write_all(auth_success.as_bytes()).await.unwrap();
+
+                // Read state command
                 let mut reader = BufReader::new(socket);
-                let mut line = String::new();
-                reader.read_line(&mut line).await.unwrap();
+                let mut cmd_line = String::new();
+                reader.read_line(&mut cmd_line).await.unwrap();
 
-                if line.trim() == "state" {
-                    // Send response terminated by END
-                    let state_response = "1622300000,CONNECTED,SUCCESS,10.8.0.6,192.0.2.1\nEND\n";
+                if cmd_line.trim() == "state" {
+                    let state_response = "1622300000,CONNECTING,WAIT,,,\nEND\n";
                     let mut socket = reader.into_inner();
                     socket.write_all(state_response.as_bytes()).await.unwrap();
                 }
             }
-        });
+        }
+    });
 
-        // Instantiate OpenVpnProvider connecting to mock server
-        let provider = OpenVpnProvider::new(local_addr.to_string());
+    // Instantiate OpenVpnProvider with password
+    let provider =
+        OpenVpnProvider::new(local_addr.to_string()).with_password("my_secret_pass".to_string());
 
-        // Verify status check succeeds and parses correctly
-        let status = provider.status().await.unwrap();
-        assert_eq!(status, VpnStatus::Connected);
-    }
-
-    #[tokio::test]
-    async fn test_openvpn_provider_password_authentication() {
-        // Start a mock OpenVPN management server requiring password
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let local_addr = listener.local_addr().unwrap();
-
-        // Spawn mock server handler
-        tokio::spawn(async move {
-            if let Ok((mut socket, _)) = listener.accept().await {
-                // 1. Send welcome banner and ENTER PASSWORD challenge
-                let greeting = ">INFO:OpenVPN Management Interface\nENTER PASSWORD:\n";
-                socket.write_all(greeting.as_bytes()).await.unwrap();
-
-                // 2. Read password from client
-                let mut reader = BufReader::new(socket);
-                let mut password_line = String::new();
-                reader.read_line(&mut password_line).await.unwrap();
-
-                if password_line.trim() == "my_secret_pass" {
-                    // Send success response
-                    let auth_success = "SUCCESS: password is correct\n>INFO: authenticated\n";
-                    let mut socket = reader.into_inner();
-                    socket.write_all(auth_success.as_bytes()).await.unwrap();
-
-                    // Read state command
-                    let mut reader = BufReader::new(socket);
-                    let mut cmd_line = String::new();
-                    reader.read_line(&mut cmd_line).await.unwrap();
-
-                    if cmd_line.trim() == "state" {
-                        let state_response = "1622300000,CONNECTING,WAIT,,,\nEND\n";
-                        let mut socket = reader.into_inner();
-                        socket.write_all(state_response.as_bytes()).await.unwrap();
-                    }
-                }
-            }
-        });
-
-        // Instantiate OpenVpnProvider with password
-        let provider = OpenVpnProvider::new(local_addr.to_string())
-            .with_password("my_secret_pass".to_string());
-
-        // Verify status parses CONNECTING correctly
-        let status = provider.status().await.unwrap();
-        assert_eq!(status, VpnStatus::Connecting);
-    }
+    // Verify status parses CONNECTING correctly
+    let status = provider.status().await.unwrap();
+    assert_eq!(status, VpnStatus::Connecting);
 }

--- a/aura-docs/project/TASKS.md
+++ b/aura-docs/project/TASKS.md
@@ -4,13 +4,7 @@ All active development tasks, technical debt, and feature requests are managed e
 
 ## Open Tasks
 
-### Critical (P0)
-- [ ] **feat: Implement ResourceGovernor for global memory backpressure** (Issue #207) `[module:core, priority:critical]`
-
 ### High (P1)
-- [ ] **feat: Advisory file locking (flock) on active download files** (Issue #208) `[module:storage, priority:high]`
-- [ ] **feat: Generational write-request validation in Storage Engine** (Issue #209) `[module:storage, priority:high]`
-- [ ] **feat: PersistentState trait and DHT routing table persistence** (Issue #210) `[module:core, priority:high]`
 - [ ] **feat: PolicyManager error classification and retry coordinator** (Issue #211) `[module:core, priority:high]`
 - [ ] **feat: Implement hierarchical configuration file resolution and CLI overrides** (Issue #214) `[module:core, module:daemon, module:cli, priority:high]`
 
@@ -29,6 +23,10 @@ All active development tasks, technical debt, and feature requests are managed e
 
 ## Completed Tasks
 
+- [x] **feat: Implement ResourceGovernor for global memory backpressure** (Issue #207) `[module:core, priority:critical]`
+- [x] **feat: Advisory file locking (flock) on active download files** (Issue #208) `[module:storage, priority:high]`
+- [x] **feat: Generational write-request validation in Storage Engine** (Issue #209) `[module:storage, priority:high]`
+- [x] **feat: PersistentState trait and DHT routing table persistence** (Issue #210) `[module:core, priority:high]`
 - [x] **chore: Document safety invariants for all unsafe blocks** (Issue #213) `[module:core, priority:moderate]`
 - [x] **bug: Remove default hardcoded RPC secret token** (Issue #201) `[module:daemon, priority:critical]`
 - [x] **bug: Daemon binds to 0.0.0.0 (all interfaces) by default** (Issue #202) `[module:daemon, priority:critical]`


### PR DESCRIPTION
## Description

This PR implements the `PersistentState` trait and serializes/deserializes the DHT routing table nodes to/from JSON in `~/.aura/dht.dat` to prevent long bootstrap delays when restarting the daemon. It also resolves Clippy warnings (unused mut, nested test module inception, and boolean assertion comparison) and updates the task tracker.

Fixes #210

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
- [x] Any dependent changes have been merged and published in downstream modules
