### PR TITLE
fix: initialize and persist Prometheus metrics registry in daemon state

### DIFF
--- a/aura-daemon/src/lib.rs
+++ b/aura-daemon/src/lib.rs
@@ -126,9 +126,38 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    let metrics = Arc::new(metrics::DaemonMetrics::new());
+
+    // Spawn background metrics updater
+    let engine_metrics = Arc::clone(&engine);
+    let metrics_updater = Arc::clone(&metrics);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+        loop {
+            interval.tick().await;
+            if let Ok(active_tasks) = engine_metrics.tell_active().await {
+                let mut dl = 0.0;
+                let mut ul = 0.0;
+                let mut st = 0.0;
+
+                for task in &active_tasks {
+                    dl += task.completed_length as f64;
+                    ul += task.uploaded_length as f64;
+                    st += task.subtasks.iter().filter(|s| s.active).count() as f64;
+                }
+
+                metrics_updater.task_count.set(active_tasks.len() as f64);
+                metrics_updater.total_downloaded.set(dl);
+                metrics_updater.total_uploaded.set(ul);
+                metrics_updater.subtask_count.set(st);
+            }
+        }
+    });
+
     let state = Arc::new(AppState {
         engine: Arc::clone(&engine),
         rpc_secret: Some(rpc_secret),
+        metrics,
     });
 
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel::<()>(1);

--- a/aura-daemon/src/metrics.rs
+++ b/aura-daemon/src/metrics.rs
@@ -5,57 +5,68 @@ use axum::{
     http::{header, StatusCode},
     response::{IntoResponse, Response},
 };
+use prometheus::{Gauge, Registry};
 use std::sync::Arc;
 
-pub async fn metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    use prometheus::{Encoder, Gauge, Registry, TextEncoder};
+pub struct DaemonMetrics {
+    pub registry: Registry,
+    pub task_count: Gauge,
+    pub total_downloaded: Gauge,
+    pub total_uploaded: Gauge,
+    pub subtask_count: Gauge,
+}
 
-    let registry = Registry::new();
-    let active_tasks = state.engine.tell_active().await.unwrap_or_default();
+impl DaemonMetrics {
+    pub fn new() -> Self {
+        let registry = Registry::new();
 
-    let task_count = Gauge::new("aura_tasks_active", "Number of active tasks").unwrap();
-    registry.register(Box::new(task_count.clone())).unwrap();
-    task_count.set(active_tasks.len() as f64);
+        let task_count = Gauge::new("aura_tasks_active", "Number of active tasks").unwrap();
+        registry.register(Box::new(task_count.clone())).unwrap();
 
-    let total_downloaded = Gauge::new(
-        "aura_bytes_downloaded_total",
-        "Total bytes downloaded across all tasks",
-    )
-    .unwrap();
-    registry
-        .register(Box::new(total_downloaded.clone()))
+        let total_downloaded = Gauge::new(
+            "aura_bytes_downloaded_total",
+            "Total bytes downloaded across all tasks",
+        )
         .unwrap();
+        registry
+            .register(Box::new(total_downloaded.clone()))
+            .unwrap();
 
-    let total_uploaded = Gauge::new(
-        "aura_bytes_uploaded_total",
-        "Total bytes uploaded across all tasks",
-    )
-    .unwrap();
-    registry.register(Box::new(total_uploaded.clone())).unwrap();
+        let total_uploaded = Gauge::new(
+            "aura_bytes_uploaded_total",
+            "Total bytes uploaded across all tasks",
+        )
+        .unwrap();
+        registry.register(Box::new(total_uploaded.clone())).unwrap();
 
-    let subtask_count = Gauge::new(
-        "aura_subtasks_active",
-        "Total number of active protocol workers",
-    )
-    .unwrap();
-    registry.register(Box::new(subtask_count.clone())).unwrap();
+        let subtask_count = Gauge::new(
+            "aura_subtasks_active",
+            "Total number of active protocol workers",
+        )
+        .unwrap();
+        registry.register(Box::new(subtask_count.clone())).unwrap();
 
-    let mut dl = 0.0;
-    let mut ul = 0.0;
-    let mut st = 0.0;
-
-    for task in active_tasks {
-        dl += task.completed_length as f64;
-        ul += task.uploaded_length as f64;
-        st += task.subtasks.iter().filter(|s| s.active).count() as f64;
+        Self {
+            registry,
+            task_count,
+            total_downloaded,
+            total_uploaded,
+            subtask_count,
+        }
     }
+}
 
-    total_downloaded.set(dl);
-    total_uploaded.set(ul);
-    subtask_count.set(st);
+impl Default for DaemonMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub async fn metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    use prometheus::{Encoder, TextEncoder};
 
     let encoder = TextEncoder::new();
-    let metric_families = registry.gather();
+    let metric_families = state.metrics.registry.gather();
     let mut buffer = Vec::new();
     encoder.encode(&metric_families, &mut buffer).unwrap();
 
@@ -65,3 +76,7 @@ pub async fn metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoRes
         .body(Body::from(buffer))
         .unwrap()
 }
+
+#[cfg(test)]
+#[path = "metrics_tests.rs"]
+mod tests;

--- a/aura-daemon/src/metrics_tests.rs
+++ b/aura-daemon/src/metrics_tests.rs
@@ -1,0 +1,66 @@
+use super::*;
+use axum::{extract::State, response::IntoResponse};
+
+#[tokio::test]
+async fn test_metrics_registration() {
+    let dm = DaemonMetrics::new();
+    let families = dm.registry.gather();
+
+    // Verify all 4 metrics are registered
+    let mut names: Vec<String> = families.iter().map(|f| f.name().to_string()).collect();
+    names.sort();
+
+    assert_eq!(
+        names,
+        vec![
+            "aura_bytes_downloaded_total".to_string(),
+            "aura_bytes_uploaded_total".to_string(),
+            "aura_subtasks_active".to_string(),
+            "aura_tasks_active".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_metrics_handler() {
+    // Bootstrap minimal engine
+    let mut config = aura_core::Config::default();
+    config.network.listen_port = 0; // prevent conflict
+    let (engine, _orch, _store) = aura_core::orchestrator::Engine::new(config).await.unwrap();
+    let engine = Arc::new(engine);
+
+    let metrics = Arc::new(DaemonMetrics::new());
+    // Manually set some metric values to check output formatting
+    metrics.task_count.set(3.0);
+    metrics.total_downloaded.set(1024.0);
+    metrics.total_uploaded.set(512.0);
+    metrics.subtask_count.set(5.0);
+
+    let state = Arc::new(AppState {
+        engine,
+        rpc_secret: None,
+        metrics,
+    });
+
+    let response = metrics_handler(State(state)).await.into_response();
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+    let headers = response.headers();
+    assert!(headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains("text/plain"));
+
+    // Extract body bytes
+    let body_bytes = axum::body::to_bytes(response.into_body(), 10000)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+    assert!(body_str.contains("aura_tasks_active 3"));
+    assert!(body_str.contains("aura_bytes_downloaded_total 1024"));
+    assert!(body_str.contains("aura_bytes_uploaded_total 512"));
+    assert!(body_str.contains("aura_subtasks_active 5"));
+}

--- a/aura-daemon/src/types.rs
+++ b/aura-daemon/src/types.rs
@@ -34,4 +34,5 @@ pub struct WsQuery {
 pub struct AppState {
     pub engine: Arc<Engine>,
     pub rpc_secret: Option<String>,
+    pub metrics: Arc<super::metrics::DaemonMetrics>,
 }

--- a/aura-daemon/tests/ws_test.rs
+++ b/aura-daemon/tests/ws_test.rs
@@ -28,6 +28,7 @@ async fn test_ws_telemetry() {
     let state = Arc::new(AppState {
         engine: engine.clone(),
         rpc_secret: Some("test-secret".to_string()),
+        metrics: Arc::new(aura_daemon::metrics::DaemonMetrics::new()),
     });
 
     let app = create_router(state);

--- a/aura-docs/project/TASKS.md
+++ b/aura-docs/project/TASKS.md
@@ -7,7 +7,6 @@ All active development tasks, technical debt, and feature requests are managed e
 ### High (P1)
 
 ### Moderate (P2)
-- [ ] **bug: Initialize and persist Prometheus metrics registry in daemon state** (Issue #212) `[module:daemon, priority:moderate]`
 - [ ] **infra: Add CI cross-platform matrix and cargo audit workflow** (Issue #148) `[infra, priority:moderate]`
 - [ ] **chore: Refactor FTPS to use rustls (ADR 0048 parity)** (Issue #189) `[module:worker, priority:moderate]`
 - [ ] **feat: Prioritized Streaming Mode for Media Playback** (Issue #28) `[module:core, priority:moderate]`
@@ -21,6 +20,7 @@ All active development tasks, technical debt, and feature requests are managed e
 
 ## Completed Tasks
 
+- [x] **bug: Initialize and persist Prometheus metrics registry in daemon state** (Issue #212) `[module:daemon, priority:moderate]`
 - [x] **feat: Implement hierarchical configuration file resolution and CLI overrides** (Issue #214) `[module:core, module:daemon, module:cli, priority:high]`
 - [x] **feat: PolicyManager error classification and retry coordinator** (Issue #211) `[module:core, priority:high]`
 - [x] **feat: Implement ResourceGovernor for global memory backpressure** (Issue #207) `[module:core, priority:critical]`


### PR DESCRIPTION
## Description

This PR fixes Issue #212 by instantiating the Prometheus `Registry` and its metrics once at daemon initialization, rather than on every incoming scrape request. It saves them in the shared web state (`AppState`) and updates them asynchronously on a background interval loop.

Specifically:
- Defined `DaemonMetrics` in `metrics.rs` to initialize and register metrics (`aura_tasks_active`, `aura_bytes_downloaded_total`, `aura_bytes_uploaded_total`, `aura_subtasks_active`) under a long-lived registry.
- Saved `metrics: Arc<DaemonMetrics>` inside Axum's shared `AppState`.
- Spawned a background updater task in `lib.rs` that polls `Engine::tell_active()` on a 5-second interval and updates the Gauges.
- Refactored `metrics_handler` to simply gather and encode the cached metrics immediately upon scrape requests.
- Created `metrics_tests.rs` unit tests to verify metrics registration and response formatting.
- Updated `TASKS.md` tracker file.

Fixes #212

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
- [x] Any dependent changes have been merged and published in downstream modules
