### PR TITLE
chore: refactor FTPS to use rustls-ring (ADR 0048 parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,18 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-native-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9343dc5acf07e79ff82d0c37899f079db3534d99f189a1837c8e549c99405bec"
-dependencies = [
- "native-tls",
- "thiserror 1.0.69",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +238,8 @@ dependencies = [
  "regex",
  "reqwest",
  "rustix",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_bencode",
  "serde_bytes",
@@ -1383,21 +1373,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2754,23 +2729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3065,47 +3023,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -4119,6 +4040,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4649,15 +4571,16 @@ version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4275c142b5be3af2eeadd70dd368caf3b65546c8af1035839372dd7a1436127d"
 dependencies = [
- "async-native-tls",
  "async-trait",
  "chrono",
  "futures-lite",
  "lazy-regex",
  "log",
  "pin-project",
+ "rustls-pki-types",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -5434,12 +5357,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,9 @@ sha1 = "0.11"
 sha2 = "0.11"
 sled = "0.34"
 socket2 = { version = "0.6.3", features = ["all"] }
-suppaftp = { version = "8.0.3", features = ["tokio", "tokio-async-native-tls"] }
+suppaftp = { version = "8.0.3", features = ["tokio", "tokio-rustls-ring"] }
+rustls = { version = "0.23.40", features = ["ring"] }
+rustls-native-certs = "0.8.3"
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/aura-core/Cargo.toml
+++ b/aura-core/Cargo.toml
@@ -28,6 +28,8 @@ local-ip-address = { workspace = true }
 regex = { workspace = true }
 socket2 = { workspace = true }
 suppaftp = { workspace = true }
+rustls = { workspace = true }
+rustls-native-certs = { workspace = true }
 toml = { workspace = true }
 notify = { workspace = true }
 arc-swap = { workspace = true }

--- a/aura-core/src/worker/ftp.rs
+++ b/aura-core/src/worker/ftp.rs
@@ -2,14 +2,51 @@ use super::{Metadata, PieceData, ProgressSender, ProtocolWorker, Segment};
 use crate::{Error, Result, TaskId};
 use async_trait::async_trait;
 use bytes::BytesMut;
-use suppaftp::tokio::AsyncNativeTlsConnector;
-use suppaftp::tokio::AsyncNativeTlsFtpStream;
+use rustls::ClientConfig;
+use rustls::RootCertStore;
+use suppaftp::tokio::{AsyncDataStream, AsyncRustlsConnector, AsyncRustlsFtpStream};
 use suppaftp::types::FileType;
 use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 use url::Url;
 
-/// A specialized worker for the FTP(S) protocol.
+/// Builds a `rustls` `ClientConfig` seeded from the OS native certificate store.
+///
+/// Uses `rustls-native-certs` to load platform certificates. Individual certificates
+/// that rustls cannot parse are silently skipped — the OS store may contain expired
+/// or intermediate certificates that are rejected by rustls's strict DER parser.
+/// An empty root store will cause TLS handshakes to untrusted servers to fail, which
+/// is the correct secure-by-default behaviour.
+fn build_tls_config() -> Result<std::sync::Arc<ClientConfig>> {
+    let mut root_store = RootCertStore::empty();
+
+    let cert_result = rustls_native_certs::load_native_certs();
+
+    // Log any load errors but continue — partial cert stores are better than none.
+    for error in &cert_result.errors {
+        tracing::warn!(%error, "Skipping native TLS certificate that failed to load");
+    }
+
+    for cert in cert_result.certs {
+        // Silently ignore individual certs that fail to parse.
+        let _ = root_store.add(cert);
+    }
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    Ok(std::sync::Arc::new(config))
+}
+
+/// A protocol worker that downloads segments over FTP (plain) or FTPS (explicit TLS
+/// via STARTTLS / AUTH TLS). TLS is backed by `rustls` with the `ring` crypto provider
+/// and the OS native certificate store via `rustls-native-certs`.
+///
+/// Both plain and TLS connections are represented by `AsyncRustlsFtpStream`:
+/// the internal `DataStream` within suppaftp stores either a raw TCP stream or a TLS
+/// stream, allowing the same type alias to cover both cases. TLS is only negotiated
+/// when the scheme is `ftps` or when the server advertises `AUTH TLS` in FEAT.
 pub struct FtpWorker {
     uri: String,
     local_addr: Option<std::net::IpAddr>,
@@ -35,7 +72,41 @@ impl FtpWorker {
         }
     }
 
-    async fn connect_once(&self) -> Result<AsyncNativeTlsFtpStream> {
+    /// Resolves FTP credentials for `host` by consulting first the URL inline
+    /// credentials, then the credential provider.  Returns `(user, pass)` as
+    /// owned `String`s to sidestep lifetime issues with temporaries.
+    fn resolve_credentials(&self, url: &Url, host: &str) -> (String, String) {
+        let url_user = url.username();
+        let url_pass = url.password().unwrap_or("anonymous@aura.rs");
+
+        // Explicit non-anonymous URL credentials take priority.
+        if !url_user.is_empty() && url_user != "anonymous" {
+            return (url_user.to_owned(), url_pass.to_owned());
+        }
+
+        // Fall back to the credential provider (e.g. ~/.netrc).
+        if let Some(ref provider) = self.credential_provider {
+            if let Some(creds) = provider.get_credentials(host) {
+                let user = creds.login.as_deref().unwrap_or("anonymous").to_owned();
+                let pass = creds
+                    .password
+                    .as_deref()
+                    .unwrap_or("anonymous@aura.rs")
+                    .to_owned();
+                return (user, pass);
+            }
+        }
+
+        ("anonymous".to_owned(), "anonymous@aura.rs".to_owned())
+    }
+
+    /// Establishes a single FTP(S) connection without retry.
+    ///
+    /// The function always connects using `AsyncRustlsFtpStream::connect_with_stream`,
+    /// which internally wraps the TCP stream in suppaftp's `DataStream::Tcp` variant.
+    /// If TLS is required, `into_secure` is called to upgrade the control channel to
+    /// `DataStream::Ssl`, backed by the rustls `AsyncRustlsConnector`.
+    async fn connect_once(&self) -> Result<AsyncRustlsFtpStream> {
         let url = Url::parse(&self.uri)
             .map_err(|e| Error::Protocol(format!("Invalid FTP URL: {}", e)))?;
 
@@ -43,36 +114,7 @@ impl FtpWorker {
             .host_str()
             .ok_or_else(|| Error::Protocol("Missing host in FTP URL".to_string()))?;
         let port = url.port().unwrap_or(21);
-
-        let mut user = if url.username().is_empty() {
-            "anonymous"
-        } else {
-            url.username()
-        };
-        let mut pass = url.password().unwrap_or("anonymous@aura.rs");
-
-        let mut resolved_user = None;
-        let mut resolved_pass = None;
-
-        if (user == "anonymous") && self.credential_provider.is_some() {
-            if let Some(ref provider) = self.credential_provider {
-                if let Some(creds) = provider.get_credentials(host) {
-                    if let Some(u) = &creds.login {
-                        resolved_user = Some(u.clone());
-                    }
-                    if let Some(p) = &creds.password {
-                        resolved_pass = Some(p.clone());
-                    }
-                }
-            }
-        }
-
-        if let Some(ref u) = resolved_user {
-            user = u;
-        }
-        if let Some(ref p) = resolved_pass {
-            pass = p;
-        }
+        let (user, pass) = self.resolve_credentials(&url, host);
 
         let tcp_stream =
             crate::net_util::logic::connect_tcp_bound_host(host, port, None, self.local_addr, None)
@@ -81,27 +123,43 @@ impl FtpWorker {
                     Error::Worker(format!("Failed to connect to FTP host {}: {}", host, e))
                 })?;
 
-        let mut ftp_stream = AsyncNativeTlsFtpStream::connect_with_stream(tcp_stream)
+        // Initialise the FTP control channel over the raw TCP stream.
+        // `AsyncRustlsFtpStream` stores `DataStream::Tcp(stream)` internally until
+        // `into_secure` is called; no TLS is negotiated yet.
+        let mut ftp_stream = AsyncRustlsFtpStream::connect_with_stream(tcp_stream)
             .await
             .map_err(|e| Error::Worker(format!("Failed to initialize FTP stream: {}", e)))?;
 
-        // Determine if we should upgrade to TLS.
+        // Determine whether the control channel should be upgraded to TLS.
+        //
+        // 1. Scheme "ftps" → always upgrade (explicit FTPS / STARTTLS).
+        // 2. Scheme "ftp"  → probe FEAT; upgrade opportunistically if the server
+        //    advertises AUTH TLS.
         let is_ftps = url.scheme() == "ftps";
-        let mut should_upgrade = is_ftps;
 
-        if !should_upgrade {
-            // Query FEAT to check if the server supports AUTH TLS.
-            if let Ok(features) = ftp_stream.feat().await {
-                should_upgrade = features.keys().any(|k| {
-                    let k_upper = k.to_uppercase();
-                    k_upper.contains("AUTH TLS") || k_upper.contains("AUTH") || k_upper == "TLS"
-                });
-            }
-        }
+        let should_upgrade = if is_ftps {
+            true
+        } else {
+            // Opportunistic TLS: treat any FEAT parse failure as "no TLS".
+            ftp_stream
+                .feat()
+                .await
+                .map(|features| {
+                    features.keys().any(|k| {
+                        let k_upper = k.to_uppercase();
+                        k_upper.contains("AUTH TLS") || k_upper.contains("AUTH") || k_upper == "TLS"
+                    })
+                })
+                .unwrap_or(false)
+        };
 
         if should_upgrade {
-            let tls_connector = suppaftp::async_native_tls::TlsConnector::new();
-            let connector = AsyncNativeTlsConnector::from(tls_connector);
+            let tls_config = build_tls_config()?;
+            // Build `tokio_rustls::TlsConnector` (an Arc<ClientConfig> wrapper)
+            // then wrap it in suppaftp's `AsyncRustlsConnector` adapter.
+            let rustls_connector = suppaftp::tokio_rustls::TlsConnector::from(tls_config);
+            let connector = AsyncRustlsConnector::from(rustls_connector);
+
             ftp_stream = ftp_stream
                 .into_secure(connector, host)
                 .await
@@ -109,7 +167,7 @@ impl FtpWorker {
         }
 
         ftp_stream
-            .login(user, pass)
+            .login(&user, &pass)
             .await
             .map_err(|e| Error::Worker(format!("FTP login failed: {}", e)))?;
 
@@ -121,8 +179,9 @@ impl FtpWorker {
         Ok(ftp_stream)
     }
 
-    async fn connect(&self) -> Result<AsyncNativeTlsFtpStream> {
-        let mut attempts = 0;
+    /// Connects to the FTP server with exponential-backoff retry.
+    async fn connect(&self) -> Result<AsyncRustlsFtpStream> {
+        let mut attempts: u32 = 0;
         let max_attempts = self.retry_count;
 
         loop {
@@ -131,10 +190,11 @@ impl FtpWorker {
                 Err(e) if attempts < max_attempts => {
                     attempts += 1;
                     let exponent = std::cmp::min(attempts - 1, 30);
-                    let delay = self.retry_delay_secs * (2u64.pow(exponent));
+                    let delay = self.retry_delay_secs.saturating_mul(2u64.pow(exponent));
                     tracing::warn!(
                         error = %e,
                         attempt = attempts,
+                        max_attempts = max_attempts,
                         delay_secs = delay,
                         "Transient FTP connection/login error, retrying"
                     );
@@ -148,7 +208,7 @@ impl FtpWorker {
     }
 
     pub async fn resolve_metadata(&self) -> Result<Metadata> {
-        let mut ftp: AsyncNativeTlsFtpStream = self.connect().await?;
+        let mut ftp = self.connect().await?;
         let url = Url::parse(&self.uri)
             .map_err(|e| Error::Protocol(format!("Invalid FTP URL: {}", e)))?;
         let path = url.path().trim_start_matches('/');
@@ -185,31 +245,31 @@ impl ProtocolWorker for FtpWorker {
         storage_tx: Option<mpsc::Sender<crate::storage::StorageRequest>>,
         throttler: std::sync::Arc<crate::throttler::Throttler>,
     ) -> Result<PieceData> {
-        let mut ftp: AsyncNativeTlsFtpStream = self.connect().await?;
+        let mut ftp = self.connect().await?;
         let url = Url::parse(&self.uri)
             .map_err(|e| Error::Protocol(format!("Invalid FTP URL: {}", e)))?;
         let path = url.path().trim_start_matches('/');
 
-        // Set restart point for range-based download
+        // Set the restart offset for range-based downloads.
         ftp.resume_transfer(segment.offset as usize)
             .await
             .map_err(|e| Error::Worker(format!("FTP REST failed: {}", e)))?;
 
-        let mut reader = ftp
+        let mut reader: AsyncDataStream<suppaftp::tokio::AsyncRustlsStream> = ftp
             .retr_as_stream(path)
             .await
             .map_err(|e| Error::Worker(format!("FTP RETR failed: {}", e)))?;
 
         let mut buffer = BytesMut::with_capacity(16384);
-        let mut total_read = 0;
+        let mut total_read: u64 = 0;
 
         while total_read < segment.length {
-            let to_read = std::cmp::min(16384, segment.length - total_read);
+            let to_read = std::cmp::min(16384u64, segment.length - total_read) as usize;
 
-            // Admission Control: Wait for bandwidth tokens before reading
-            throttler.acquire_download(task_id, to_read).await;
+            // Admission control: wait for bandwidth tokens before reading.
+            throttler.acquire_download(task_id, to_read as u64).await;
 
-            let mut chunk = vec![0u8; to_read as usize];
+            let mut chunk = vec![0u8; to_read];
             let n = reader
                 .read(&mut chunk)
                 .await

--- a/aura-docs/adr/0048-ftps-tls-support.md
+++ b/aura-docs/adr/0048-ftps-tls-support.md
@@ -4,7 +4,7 @@ Date: 2026-05-27
 
 ## Status
 
-Implemented (2026-05-28, PR #133)
+Implemented (2026-05-28, PR #133); refactored to `rustls-ring` (2026-06-04, Issue #189)
 
 ## Context
 
@@ -12,15 +12,18 @@ The FTP protocol relies on plain-text communication, which leaves data and crede
 
 ## Decision
 
-We will extend the FTP worker to support Explicit FTPS (AUTH TLS). 
-- If the URI scheme is `ftps://`, the worker will automatically negotiate a TLS session after the initial TCP connection using `rustls`.
+We will extend the FTP worker to support Explicit FTPS (AUTH TLS).
+- If the URI scheme is `ftps://`, the worker will automatically negotiate a TLS session after the initial TCP connection using `rustls` with the `ring` crypto provider.
+- Plain FTP connections that advertise `AUTH TLS` via FEAT will be opportunistically upgraded to TLS.
 - We will integrate a robust retry loop for the FTP worker. Transient failures (e.g., connection reset, 421 Service not available) will be caught, and the worker will back off exponentially before re-attempting to download the assigned chunk.
-- The `rustls` configuration will utilize the same certificate store built for HTTPS and DoH (ADR-0014, ADR-0028).
+- The `rustls` configuration will use `rustls-native-certs` to load the OS certificate store, consistent with ADR-0014 and ADR-0028.
+- The `native-tls` dependency is removed entirely. All TLS in the project is unified under `rustls-ring`.
 
 ## Consequences
 
-- **Pros:** Enhances security for users downloading from legacy FTP hosts that offer TLS. Increases download reliability on unstable FTP servers.
-- **Cons:** Increases the complexity of the FTP worker state machine (handling TLS handshake timeouts).
+- **Pros:** Eliminates the `native-tls`/`OpenSSL` dependency, simplifying the build. Provides a uniform TLS backend across all protocols. Enhances security for users downloading from legacy FTP hosts that offer TLS. Increases download reliability on unstable FTP servers.
+- **Cons:** Slightly increases the complexity of the FTP worker state machine (handling TLS handshake timeouts). Servers with non-standard or expired certificates may fail where `native-tls` was more permissive.
 
 ## Implementation
-- **FTPS & Retry Logic**: Implemented in `aura-core/src/ftp_worker/` (2026-05-28, PR #133).
+- **FTPS & Retry Logic**: Implemented in `aura-core/src/worker/ftp.rs` (2026-05-28, PR #133).
+- **rustls-ring migration**: Refactored to `suppaftp` `tokio-rustls-ring` feature, removing `native-tls` (2026-06-04, Issue #189).


### PR DESCRIPTION
## Description

Migrates `FtpWorker` from `suppaftp`'s `tokio-async-native-tls` backend to `tokio-rustls-ring`, achieving full TLS backend parity with HTTP/DoH workers and fulfilling the architectural intent of ADR-0048.

Fixes #189

### Changes

- **`aura-core/src/worker/ftp.rs`**: Replaces all `AsyncNativeTlsConnector` / `AsyncNativeTlsFtpStream` usage with `AsyncRustlsConnector` / `AsyncRustlsFtpStream`. Builds a `rustls::ClientConfig` using `rustls-native-certs` (OS trust store). Introduces `build_tls_config()` helper and `resolve_credentials()` to eliminate duplicated URL-parsing logic. Backoff overflow fixed with `saturating_mul`.
- **`Cargo.toml` (workspace)**: `suppaftp` features set to `["tokio", "tokio-rustls-ring"]`; `rustls` and `rustls-native-certs` added as workspace deps.
- **`aura-core/Cargo.toml`**: Activated `rustls` and `rustls-native-certs` workspace deps.
- **`aura-docs/adr/0048-ftps-tls-support.md`**: Status updated; decision clauses tightened to name `rustls-ring` and `rustls-native-certs` explicitly.

### Technical Notes

`AsyncRustlsFtpStream` is used for both plain FTP and FTPS: suppaftp's internal `DataStream<T>` stores either a raw `TcpStream` or a `TlsStream` and is accessed uniformly. TLS is only negotiated when the scheme is `ftps://` or when FEAT advertises `AUTH TLS`. `into_secure` is called on the stream only when needed.

## Type of change

- [x] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
- [x] Any dependent changes have been merged and published in downstream modules