### PR TITLE
feat(seeding-limits): Implement BitTorrent seeding limits and overrides

### DIFF
--- a/Aura.example.toml
+++ b/Aura.example.toml
@@ -54,8 +54,11 @@ request_pipeline_size = 10             # Number of in-flight requests per peer
 dht_enabled = true                     # Enable Distributed Hash Table
 pex_enabled = true                     # Enable Peer Exchange
 lpd_enabled = false                    # Enable Local Peer Discovery (Multicast)
-seed_ratio = 1.0                       # Default seed ratio target
-seed_time_mins = 0                     # Seed time limit (0 for infinite)
+[bittorrent.seeding]
+min_ratio        = 1.0  # Stop when uploaded >= downloaded × ratio (0.0 = seed forever)
+max_seeding_time = 0    # Stop after N seconds (0 = no time limit)
+stop_on_either   = true # true = stop on EITHER condition; false = require BOTH
+
 endgame_mode_enabled = true            # Enable parallel fetching for final blocks
 min_split_size_mb = 20                 # Minimum piece/segment size for splitting
 

--- a/Aura.toml
+++ b/Aura.toml
@@ -34,8 +34,11 @@ request_pipeline_size = 10             # Number of in-flight requests per peer
 dht_enabled = true                     # Enable Distributed Hash Table
 pex_enabled = true                     # Enable Peer Exchange
 lpd_enabled = false                    # Enable Local Peer Discovery (Multicast)
-seed_ratio = 1.0                       # Default seed ratio target
-seed_time_mins = 0                     # Seed time limit (0 for infinite)
+[bittorrent.seeding]
+min_ratio        = 1.0  # Stop when uploaded >= downloaded × ratio (0.0 = seed forever)
+max_seeding_time = 0    # Stop after N seconds (0 = no time limit)
+stop_on_either   = true # true = stop on EITHER condition; false = require BOTH
+
 endgame_mode_enabled = true            # Enable parallel fetching for final blocks
 min_split_size_mb = 20                 # Minimum piece/segment size for splitting
 

--- a/aura-cli/src/lib.rs
+++ b/aura-cli/src/lib.rs
@@ -102,6 +102,8 @@ pub async fn run(args: Args) -> Result<()> {
         return Ok(());
     }
 
+    let mut is_torrent_task = std::collections::HashMap::new();
+
     // If output is specified, we treat all URIs as sources for that one output
     if let Some(output_name) = &args.output {
         let id = TaskId(rand::rng().random());
@@ -110,7 +112,7 @@ pub async fn run(args: Args) -> Result<()> {
 
         let mut sources = Vec::new();
         for (uri, _, _) in tasks_to_add {
-            let ttype = if uri.ends_with(".torrent") {
+            let ttype = if uri.ends_with(".torrent") || uri.starts_with("magnet:") {
                 TaskType::BitTorrent
             } else if uri.starts_with("ftp://") || uri.starts_with("ftps://") {
                 TaskType::Ftp
@@ -119,6 +121,9 @@ pub async fn run(args: Args) -> Result<()> {
             };
             sources.push((uri, ttype));
         }
+
+        let has_torrent = sources.iter().any(|(_, t)| *t == TaskType::BitTorrent);
+        is_torrent_task.insert(id, has_torrent);
 
         engine
             .add_task_with_options(aura_core::orchestrator::command::AddTaskArgs {
@@ -141,7 +146,7 @@ pub async fn run(args: Args) -> Result<()> {
                 storage.register_task(id, path, 0, None, Vec::new()).await;
             }
 
-            let ttype = if uri.ends_with(".torrent") {
+            let ttype = if uri.ends_with(".torrent") || uri.starts_with("magnet:") {
                 TaskType::BitTorrent
             } else if uri.ends_with(".metalink") || uri.ends_with(".meta4") {
                 TaskType::Http
@@ -150,6 +155,10 @@ pub async fn run(args: Args) -> Result<()> {
             } else {
                 TaskType::Http
             };
+
+            let is_torrent = ttype == TaskType::BitTorrent;
+            is_torrent_task.insert(id, is_torrent);
+
             engine
                 .add_task_with_options(aura_core::orchestrator::command::AddTaskArgs {
                     id,
@@ -231,7 +240,11 @@ pub async fn run(args: Args) -> Result<()> {
             }
             Event::TaskCompleted(id) => {
                 if let Some(pb) = bars.get(&id) {
-                    pb.finish_with_message(format!("Task {} complete", id));
+                    if is_torrent_task.get(&id).copied().unwrap_or(false) {
+                        pb.set_message("Seeding...");
+                    } else {
+                        pb.finish_with_message(format!("Task {} complete", id));
+                    }
                 }
                 if !bars.is_empty() && bars.values().all(|b| b.is_finished()) {
                     break;
@@ -253,6 +266,14 @@ pub async fn run(args: Args) -> Result<()> {
             Event::TaskResumed(id) => {
                 if let Some(pb) = bars.get(&id) {
                     pb.set_message(format!("Task {} resumed", id.0));
+                }
+            }
+            Event::SeedingComplete { id, reason } => {
+                if let Some(pb) = bars.get(&id) {
+                    pb.finish_with_message(format!("Task {} seeding complete ({:?})", id, reason));
+                }
+                if !bars.is_empty() && bars.values().all(|b| b.is_finished()) {
+                    break;
                 }
             }
         }

--- a/aura-core/src/api/logic.rs
+++ b/aura-core/src/api/logic.rs
@@ -28,6 +28,10 @@ pub enum TaskEvent {
     Completed,
     /// An error occurred during the download process.
     Error(String),
+    /// Seeding limit reached.
+    SeedingComplete {
+        reason: crate::SeedingCompleteReason,
+    },
 }
 
 /// A handle to an active or pending download task.
@@ -84,6 +88,9 @@ impl TaskHandle {
                     Event::TaskCompleted(ev_id) if ev_id == id => yield TaskEvent::Completed,
                     Event::TaskError { id: ev_id, message } if ev_id == id => {
                         yield TaskEvent::Error(message)
+                    }
+                    Event::SeedingComplete { id: ev_id, reason } if ev_id == id => {
+                        yield TaskEvent::SeedingComplete { reason }
                     }
                     _ => {}
                 }

--- a/aura-core/src/config/bittorrent.rs
+++ b/aura-core/src/config/bittorrent.rs
@@ -2,6 +2,25 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
+pub struct SeedingConfig {
+    pub min_ratio: f32,
+    #[serde(rename = "max_seeding_time")]
+    pub max_seeding_time_secs: u64,
+    pub stop_on_either: bool,
+}
+
+impl Default for SeedingConfig {
+    fn default() -> Self {
+        Self {
+            min_ratio: 1.0,
+            max_seeding_time_secs: 0,
+            stop_on_either: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct BitTorrentConfig {
     pub enabled: bool,
     pub max_peers_per_torrent: usize,
@@ -10,8 +29,7 @@ pub struct BitTorrentConfig {
     pub dht_enabled: bool,
     pub pex_enabled: bool,
     pub lpd_enabled: bool,
-    pub seed_ratio: f32,
-    pub seed_time_mins: u32,
+    pub seeding: SeedingConfig,
     pub endgame_mode_enabled: bool,
     pub min_split_size_mb: u64,
     pub max_connections_per_torrent: usize,
@@ -27,8 +45,7 @@ impl Default for BitTorrentConfig {
             dht_enabled: true,
             pex_enabled: true,
             lpd_enabled: false,
-            seed_ratio: 1.0,
-            seed_time_mins: 0,
+            seeding: SeedingConfig::default(),
             endgame_mode_enabled: true,
             min_split_size_mb: 20,
             max_connections_per_torrent: 200,

--- a/aura-core/src/config/logic.rs
+++ b/aura-core/src/config/logic.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 // Import and re-export all sub-configs from their dedicated sibling modules (Facade Pattern)
 pub use super::bandwidth::BandwidthConfig;
-pub use super::bittorrent::BitTorrentConfig;
+pub use super::bittorrent::{BitTorrentConfig, SeedingConfig};
 pub use super::general::{CredentialConfig, GeneralConfig, ThemeConfig};
 pub use super::hooks::HookConfig;
 pub use super::limits::LimitsConfig;

--- a/aura-core/src/history/mod.rs
+++ b/aura-core/src/history/mod.rs
@@ -20,7 +20,7 @@ pub struct CompletedTaskRecord {
 
 #[cfg(test)]
 thread_local! {
-    pub static HISTORY_PATH_OVERRIDE: std::cell::RefCell<Option<std::path::PathBuf>> = std::cell::RefCell::new(None);
+    pub static HISTORY_PATH_OVERRIDE: std::cell::RefCell<Option<std::path::PathBuf>> = const { std::cell::RefCell::new(None) };
 }
 
 pub struct HistoryManager;

--- a/aura-core/src/lib.rs
+++ b/aura-core/src/lib.rs
@@ -46,6 +46,12 @@ pub enum Checksum {
     Sha512(String),
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SeedingCompleteReason {
+    RatioReached,
+    TimeExpired,
+}
+
 /// Newtype for Download Task identifiers to ensure type safety.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct TaskId(pub u64);

--- a/aura-core/src/orchestrator/advanced_net_and_tenant_tests.rs
+++ b/aura-core/src/orchestrator/advanced_net_and_tenant_tests.rs
@@ -76,6 +76,8 @@ async fn test_multi_tenant_path_isolation_and_throttling() {
         extensions: HashMap::new(),
         depends_on: Vec::new(),
         stall_ticks: 0,
+        seed_ratio: None,
+        seed_time: None,
     };
     orch.tasks.insert(meta_id, meta);
 
@@ -172,6 +174,8 @@ async fn test_captive_portal_pausing() {
         depends_on: Vec::new(),
         follow_on: None,
         stall_ticks: 0,
+        seed_ratio: None,
+        seed_time: None,
     };
     orch.tasks.insert(meta_id, meta);
 
@@ -252,6 +256,8 @@ async fn test_interface_roaming_reconnector() {
         depends_on: Vec::new(),
         follow_on: None,
         stall_ticks: 0,
+        seed_ratio: None,
+        seed_time: None,
     };
     orch.tasks.insert(meta_id, meta);
 

--- a/aura-core/src/orchestrator/command.rs
+++ b/aura-core/src/orchestrator/command.rs
@@ -25,6 +25,8 @@ pub enum Command {
         id: TaskId,
         priority: Option<u32>,
         depends_on: Option<Vec<TaskId>>,
+        seed_ratio: Option<f32>,
+        seed_time: Option<u32>,
     },
     Pause(TaskId),
     Resume(TaskId),

--- a/aura-core/src/orchestrator/commands/dependency.rs
+++ b/aura-core/src/orchestrator/commands/dependency.rs
@@ -189,9 +189,12 @@ impl Orchestrator {
         id: TaskId,
         priority: Option<u32>,
         depends_on: Option<Vec<TaskId>>,
+        seed_ratio: Option<f32>,
+        seed_time: Option<u32>,
     ) -> Result<()> {
         let mut priority_changed = false;
         let mut depends_changed = false;
+        let mut seeding_changed = false;
 
         if let Some(p) = priority {
             if let Some(task) = self.tasks.get_mut(&id) {
@@ -234,7 +237,27 @@ impl Orchestrator {
             }
         }
 
-        if priority_changed || depends_changed {
+        if let Some(ratio) = seed_ratio {
+            if let Some(task) = self.tasks.get_mut(&id) {
+                if task.seed_ratio != Some(ratio) {
+                    info!(%id, from = ?task.seed_ratio, to = ?Some(ratio), "Updating task seed_ratio override");
+                    task.seed_ratio = Some(ratio);
+                    seeding_changed = true;
+                }
+            }
+        }
+
+        if let Some(time) = seed_time {
+            if let Some(task) = self.tasks.get_mut(&id) {
+                if task.seed_time != Some(time) {
+                    info!(%id, from = ?task.seed_time, to = ?Some(time), "Updating task seed_time override");
+                    task.seed_time = Some(time);
+                    seeding_changed = true;
+                }
+            }
+        }
+
+        if priority_changed || depends_changed || seeding_changed {
             let _ = self.save_task(id).await;
         }
 

--- a/aura-core/src/orchestrator/commands/lifecycle.rs
+++ b/aura-core/src/orchestrator/commands/lifecycle.rs
@@ -62,41 +62,87 @@ impl Orchestrator {
 
     pub(crate) async fn check_seed_limits(&mut self) {
         let config = self.config.load();
-        let target_ratio = config.bittorrent.seed_ratio;
-        let target_time = config.bittorrent.seed_time_mins as i64;
+        let global_ratio = config.bittorrent.seeding.min_ratio;
+        let global_time_secs = config.bittorrent.seeding.max_seeding_time_secs;
+        let global_stop_on_either = config.bittorrent.seeding.stop_on_either;
 
-        let mut to_pause = Vec::new();
+        let mut to_stop = Vec::new();
         for (id, task) in &self.tasks {
             if task.phase == crate::task::DownloadPhase::Complete {
-                // Check Ratio
-                if target_ratio > 0.0 {
-                    let current_ratio = if task.completed_length > 0 {
-                        task.uploaded_length as f64 / task.completed_length as f64
+                let is_bittorrent = task
+                    .subtasks
+                    .iter()
+                    .any(|sub| sub.task_type == crate::task::TaskType::BitTorrent);
+                if !is_bittorrent {
+                    continue;
+                }
+
+                let target_ratio = task.seed_ratio.unwrap_or(global_ratio);
+                let target_time_secs = task
+                    .seed_time
+                    .map(|mins| mins as u64 * 60)
+                    .unwrap_or(global_time_secs);
+
+                let ratio_limit_active = target_ratio > 0.0;
+                let time_limit_active = target_time_secs > 0;
+
+                if !ratio_limit_active && !time_limit_active {
+                    continue;
+                }
+
+                let ratio_reached = if ratio_limit_active {
+                    let current_ratio = if task.total_length > 0 {
+                        task.uploaded_length as f64 / task.total_length as f64
                     } else {
                         0.0
                     };
-                    if current_ratio >= target_ratio as f64 {
-                        tracing::info!(%id, current_ratio, target_ratio, "Seed ratio reached, pausing task");
-                        to_pause.push(*id);
-                        continue;
-                    }
-                }
+                    current_ratio >= target_ratio as f64
+                } else {
+                    false
+                };
 
-                // Check Time
-                if target_time > 0 {
+                let time_reached = if time_limit_active {
                     if let Some(start_time) = task.seeding_start_time {
-                        let elapsed = chrono::Utc::now() - start_time;
-                        if elapsed.num_minutes() >= target_time {
-                            tracing::info!(%id, elapsed_mins = elapsed.num_minutes(), target_time, "Seed time limit reached, pausing task");
-                            to_pause.push(*id);
+                        let elapsed_secs =
+                            (chrono::Utc::now() - start_time).num_seconds().max(0) as u64;
+                        elapsed_secs >= target_time_secs
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
+                let should_stop = match (ratio_limit_active, time_limit_active) {
+                    (true, true) => {
+                        if global_stop_on_either {
+                            ratio_reached || time_reached
+                        } else {
+                            ratio_reached && time_reached
                         }
                     }
+                    (true, false) => ratio_reached,
+                    (false, true) => time_reached,
+                    (false, false) => false,
+                };
+
+                if should_stop {
+                    let reason = if ratio_reached
+                        && (!time_reached || global_stop_on_either || !time_limit_active)
+                    {
+                        crate::SeedingCompleteReason::RatioReached
+                    } else {
+                        crate::SeedingCompleteReason::TimeExpired
+                    };
+                    to_stop.push((*id, reason));
                 }
             }
         }
 
-        for id in to_pause {
+        for (id, reason) in to_stop {
+            tracing::info!(%id, ?reason, "Seeding limit reached, stopping task");
             let _ = self.handle_pause(id).await;
+            let _ = self.event_tx.send(Event::SeedingComplete { id, reason });
         }
     }
 }

--- a/aura-core/src/orchestrator/commands/mod.rs
+++ b/aura-core/src/orchestrator/commands/mod.rs
@@ -20,8 +20,11 @@ impl Orchestrator {
                 id,
                 priority,
                 depends_on,
+                seed_ratio,
+                seed_time,
             } => {
-                self.handle_change_option(id, priority, depends_on).await?;
+                self.handle_change_option(id, priority, depends_on, seed_ratio, seed_time)
+                    .await?;
             }
             Command::Pause(id) => {
                 self.handle_pause(id).await?;

--- a/aura-core/src/orchestrator/engine_api.rs
+++ b/aura-core/src/orchestrator/engine_api.rs
@@ -84,12 +84,16 @@ impl Engine {
         id: TaskId,
         priority: Option<u32>,
         depends_on: Option<Vec<TaskId>>,
+        seed_ratio: Option<f32>,
+        seed_time: Option<u32>,
     ) -> Result<()> {
         self.command_tx
             .send(Command::ChangeOption {
                 id,
                 priority,
                 depends_on,
+                seed_ratio,
+                seed_time,
             })
             .await
             .map_err(|e| Error::Engine(format!("Failed to send ChangeOption command: {}", e)))?;

--- a/aura-core/src/orchestrator/event_handlers_tests.rs
+++ b/aura-core/src/orchestrator/event_handlers_tests.rs
@@ -107,6 +107,8 @@ async fn test_racing_workers_are_cancelled_on_range_finished() {
         follow_on: None,
         stall_ticks: 0,
         created_at: None,
+        seed_ratio: None,
+        seed_time: None,
     };
 
     orch.tasks.insert(meta_id, meta);
@@ -164,6 +166,8 @@ async fn test_dependency_cycle_detection() {
         depends_on: Vec::new(),
         stall_ticks: 0,
         created_at: None,
+        seed_ratio: None,
+        seed_time: None,
     };
     orch.tasks.insert(TaskId(1), meta_a);
 
@@ -190,6 +194,8 @@ async fn test_dependency_cycle_detection() {
         depends_on: vec![TaskId(1)],
         stall_ticks: 0,
         created_at: None,
+        seed_ratio: None,
+        seed_time: None,
     };
     orch.tasks.insert(TaskId(2), meta_b);
 
@@ -216,6 +222,8 @@ async fn test_dependency_cycle_detection() {
         depends_on: vec![TaskId(2)],
         stall_ticks: 0,
         created_at: None,
+        seed_ratio: None,
+        seed_time: None,
     };
     orch.tasks.insert(TaskId(3), meta_c);
 
@@ -256,6 +264,8 @@ async fn test_dependency_waiting_state_and_unblocking() {
         depends_on: Vec::new(),
         stall_ticks: 0,
         created_at: None,
+        seed_ratio: None,
+        seed_time: None,
     };
     orch.tasks.insert(TaskId(1), meta_a);
 
@@ -317,6 +327,8 @@ async fn test_follow_on_custom_trigger() {
         depends_on: Vec::new(),
         stall_ticks: 0,
         created_at: None,
+        seed_ratio: None,
+        seed_time: None,
     };
     orch.tasks.insert(meta_id, meta);
 
@@ -369,7 +381,7 @@ async fn test_dag_cycle_detection_via_add_and_change_options() {
 
     // 3. Attempting to add Task A depending on B should fail (cycle)
     let res = orch
-        .handle_change_option(TaskId(1), None, Some(vec![TaskId(2)]))
+        .handle_change_option(TaskId(1), None, Some(vec![TaskId(2)]), None, None)
         .await;
 
     assert!(res.is_err());

--- a/aura-core/src/orchestrator/monitors_tests.rs
+++ b/aura-core/src/orchestrator/monitors_tests.rs
@@ -80,6 +80,8 @@ async fn test_adaptive_scaling_min_connections() {
         depends_on: Vec::new(),
         stall_ticks: 0,
         created_at: None,
+        seed_ratio: None,
+        seed_time: None,
     };
 
     orchestrator.tasks.insert(TaskId(1), task);
@@ -90,4 +92,167 @@ async fn test_adaptive_scaling_min_connections() {
     // Assert target concurrency increased
     let scaled_task = orchestrator.tasks.get(&TaskId(1)).unwrap();
     assert_eq!(scaled_task.subtasks[0].target_concurrency, 12);
+}
+
+#[tokio::test]
+async fn test_check_seed_limits() {
+    let (mut orchestrator, _storage_rx) = make_test_orchestrator();
+
+    let sub_task1 = SubTask {
+        id: TaskId(11),
+        uri: "http://test1".to_string(),
+        task_type: TaskType::BitTorrent,
+        phase: DownloadPhase::Complete,
+        assigned_ranges: Vec::new(),
+        ewma_throughput: 0.0,
+        retry_count: 0,
+        total_length: 1000,
+        active: false,
+        completed_length: 1000,
+        recent_bytes_downloaded: 0,
+        target_concurrency: 1,
+    };
+
+    let task1 = MetaTask {
+        id: TaskId(1),
+        tenant_id: None,
+        name: "test1".to_string(),
+        total_length: 1000,
+        completed_length: 1000,
+        uploaded_length: 2000,
+        phase: DownloadPhase::Complete,
+        priority: 3,
+        streaming_mode: false,
+        range_supported: true,
+        follow_on: None,
+        subtasks: vec![sub_task1],
+        pending_ranges: Vec::new(),
+        in_flight_ranges: Vec::new(),
+        checksum: None,
+        seeding_start_time: Some(chrono::Utc::now() - chrono::Duration::seconds(10)),
+        blacklisted_uris: Vec::new(),
+        extensions: HashMap::new(),
+        depends_on: Vec::new(),
+        stall_ticks: 0,
+        created_at: None,
+        seed_ratio: None,
+        seed_time: None,
+    };
+
+    let sub_task2 = SubTask {
+        id: TaskId(12),
+        uri: "http://test2".to_string(),
+        task_type: TaskType::BitTorrent,
+        phase: DownloadPhase::Complete,
+        assigned_ranges: Vec::new(),
+        ewma_throughput: 0.0,
+        retry_count: 0,
+        total_length: 1000,
+        active: false,
+        completed_length: 1000,
+        recent_bytes_downloaded: 0,
+        target_concurrency: 1,
+    };
+
+    let task2 = MetaTask {
+        id: TaskId(2),
+        tenant_id: None,
+        name: "test2".to_string(),
+        total_length: 1000,
+        completed_length: 1000,
+        uploaded_length: 500,
+        phase: DownloadPhase::Complete,
+        priority: 3,
+        streaming_mode: false,
+        range_supported: true,
+        follow_on: None,
+        subtasks: vec![sub_task2],
+        pending_ranges: Vec::new(),
+        in_flight_ranges: Vec::new(),
+        checksum: None,
+        seeding_start_time: Some(chrono::Utc::now() - chrono::Duration::seconds(10)),
+        blacklisted_uris: Vec::new(),
+        extensions: HashMap::new(),
+        depends_on: Vec::new(),
+        stall_ticks: 0,
+        created_at: None,
+        seed_ratio: None,
+        seed_time: None,
+    };
+
+    let sub_task3 = SubTask {
+        id: TaskId(13),
+        uri: "http://test3".to_string(),
+        task_type: TaskType::BitTorrent,
+        phase: DownloadPhase::Complete,
+        assigned_ranges: Vec::new(),
+        ewma_throughput: 0.0,
+        retry_count: 0,
+        total_length: 1000,
+        active: false,
+        completed_length: 1000,
+        recent_bytes_downloaded: 0,
+        target_concurrency: 1,
+    };
+
+    let task3 = MetaTask {
+        id: TaskId(3),
+        tenant_id: None,
+        name: "test3".to_string(),
+        total_length: 1000,
+        completed_length: 1000,
+        uploaded_length: 600,
+        phase: DownloadPhase::Complete,
+        priority: 3,
+        streaming_mode: false,
+        range_supported: true,
+        follow_on: None,
+        subtasks: vec![sub_task3],
+        pending_ranges: Vec::new(),
+        in_flight_ranges: Vec::new(),
+        checksum: None,
+        seeding_start_time: Some(chrono::Utc::now() - chrono::Duration::seconds(2)),
+        blacklisted_uris: Vec::new(),
+        extensions: HashMap::new(),
+        depends_on: Vec::new(),
+        stall_ticks: 0,
+        created_at: None,
+        seed_ratio: Some(0.5),
+        seed_time: None,
+    };
+
+    orchestrator.tasks.insert(TaskId(1), task1);
+    orchestrator.tasks.insert(TaskId(2), task2);
+    orchestrator.tasks.insert(TaskId(3), task3);
+
+    // Setup global config:
+    // global min_ratio = 1.0
+    // global max_seeding_time = 5 seconds (stop_on_either = true)
+    {
+        let mut config = crate::Config::default();
+        config.bittorrent.seeding.min_ratio = 1.0;
+        config.bittorrent.seeding.max_seeding_time_secs = 5;
+        config.bittorrent.seeding.stop_on_either = true;
+        orchestrator.config.store(Arc::new(config));
+    }
+
+    orchestrator.check_seed_limits().await;
+
+    // Task 1 should be paused (ratio reached: 2.0 >= 1.0)
+    assert_eq!(
+        orchestrator.tasks.get(&TaskId(1)).unwrap().phase,
+        DownloadPhase::Paused
+    );
+
+    // Task 2 should be paused (time reached: 10s >= 5s)
+    assert_eq!(
+        orchestrator.tasks.get(&TaskId(2)).unwrap().phase,
+        DownloadPhase::Paused
+    );
+
+    // Task 3 should be paused (override ratio reached: 0.6 >= 0.5)
+    assert_eq!(
+        orchestrator.tasks.get(&TaskId(3)).unwrap().phase,
+        DownloadPhase::Paused
+    );
 }

--- a/aura-core/src/orchestrator/telemetry.rs
+++ b/aura-core/src/orchestrator/telemetry.rs
@@ -23,4 +23,8 @@ pub enum Event {
         id: TaskId,
         message: String,
     },
+    SeedingComplete {
+        id: TaskId,
+        reason: crate::SeedingCompleteReason,
+    },
 }

--- a/aura-core/src/task/logic.rs
+++ b/aura-core/src/task/logic.rs
@@ -90,6 +90,8 @@ pub struct MetaTask {
     pub depends_on: Vec<TaskId>,
     pub stall_ticks: u32,
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub seed_ratio: Option<f32>,
+    pub seed_time: Option<u32>,
 }
 
 /// Represents the serializable state of a MetaTask for persistence.
@@ -114,6 +116,10 @@ pub struct TaskState {
     pub blacklisted_uris: Option<Vec<String>>,
     pub depends_on: Option<Vec<TaskId>>,
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    pub seed_ratio: Option<f32>,
+    #[serde(default)]
+    pub seed_time: Option<u32>,
 }
 
 impl MetaTask {
@@ -138,6 +144,8 @@ impl MetaTask {
             blacklisted_uris: Some(self.blacklisted_uris.clone()),
             depends_on: Some(self.depends_on.clone()),
             created_at: self.created_at,
+            seed_ratio: self.seed_ratio,
+            seed_time: self.seed_time,
         }
     }
 
@@ -164,6 +172,8 @@ impl MetaTask {
             depends_on: state.depends_on.unwrap_or_default(),
             stall_ticks: 0,
             created_at: state.created_at,
+            seed_ratio: state.seed_ratio,
+            seed_time: state.seed_time,
         }
     }
 
@@ -190,6 +200,8 @@ impl MetaTask {
             depends_on: Vec::new(),
             stall_ticks: 0,
             created_at: Some(chrono::Utc::now()),
+            seed_ratio: None,
+            seed_time: None,
         }
     }
 

--- a/aura-core/tests/features/seeding_limits.feature
+++ b/aura-core/tests/features/seeding_limits.feature
@@ -1,0 +1,26 @@
+Feature: BitTorrent Seeding Limits Configuration and Overrides
+  As a BitTorrent user
+  I want to define global seeding limits in the config file and override them on a per-task basis
+  So that I have precise control over seeding ratio and time limits.
+
+  Scenario: Loading seeding limits from configuration
+    Given a configuration file loaded with:
+      """
+      [bittorrent]
+      enabled = true
+      [bittorrent.seeding]
+      min_ratio = 1.8
+      max_seeding_time = 7200
+      stop_on_either = false
+      """
+    Then the resolved configuration seeding ratio should be 1.8 and max_seeding_time should be 7200 and stop_on_either should be false
+
+  Scenario: Task seeding overrides via changeOption
+    Given a running engine
+    When I add a mock BitTorrent task with ID 100
+    Then the task 100 should have no seeding overrides
+    When I change options for task 100 with:
+      | Option     | Value |
+      | seed-ratio | 2.5   |
+      | seed-time  | 120   |
+    Then the task 100 should have seed_ratio 2.5 and seed_time 120

--- a/aura-core/tests/steps/mod.rs
+++ b/aura-core/tests/steps/mod.rs
@@ -8,5 +8,6 @@ pub mod hooks;
 pub mod integrity;
 pub mod networking;
 pub mod reliability;
+pub mod seeding_limits;
 pub mod storage;
 pub mod swarm;

--- a/aura-core/tests/steps/seeding_limits.rs
+++ b/aura-core/tests/steps/seeding_limits.rs
@@ -1,0 +1,98 @@
+use crate::AuraWorld;
+use aura_core::TaskId;
+use cucumber::{gherkin::Step, given, then, when};
+
+#[then(
+    expr = "the resolved configuration seeding ratio should be {float} and max_seeding_time should be {int} and stop_on_either should be {word}"
+)]
+fn then_assert_seeding_config(
+    world: &mut AuraWorld,
+    ratio: f32,
+    time: u64,
+    stop_on_either: String,
+) {
+    let config = world.resolved_config.as_ref().expect("No resolved config");
+    assert_eq!(config.bittorrent.seeding.min_ratio, ratio);
+    assert_eq!(config.bittorrent.seeding.max_seeding_time_secs, time);
+    let stop_bool = stop_on_either.parse::<bool>().unwrap();
+    assert_eq!(config.bittorrent.seeding.stop_on_either, stop_bool);
+}
+
+#[given(expr = "a running engine")]
+async fn given_running_engine(world: &mut AuraWorld) {
+    world.init_engine(|_cfg| {}).await;
+}
+
+#[when(expr = "I add a mock BitTorrent task with ID {int}")]
+async fn when_add_mock_task(world: &mut AuraWorld, id: u64) {
+    let engine = world.engine.as_ref().expect("Engine not running");
+
+    engine
+        .add_task_with_id(
+            TaskId(id),
+            format!("mock-task-{}", id),
+            "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567".to_string(),
+            aura_core::task::TaskType::BitTorrent,
+        )
+        .await
+        .expect("Failed to add task");
+
+    world.last_task_id = Some(TaskId(id));
+}
+
+#[then(expr = "the task {int} should have no seeding overrides")]
+async fn then_task_has_no_overrides(world: &mut AuraWorld, id: u64) {
+    let engine = world.engine.as_ref().expect("Engine not running");
+    let active = engine
+        .tell_active()
+        .await
+        .expect("Failed to get active tasks");
+    let task = active
+        .iter()
+        .find(|t| t.id == TaskId(id))
+        .expect("Task not found");
+    assert_eq!(task.seed_ratio, None);
+    assert_eq!(task.seed_time, None);
+}
+
+#[when(expr = "I change options for task {int} with:")]
+async fn when_change_task_options(world: &mut AuraWorld, id: u64, step: &Step) {
+    let engine = world.engine.as_ref().expect("Engine not running");
+    let table = step.table.as_ref().expect("Expected a table");
+
+    let mut seed_ratio = None;
+    let mut seed_time = None;
+
+    for row in table.rows.iter().skip(1) {
+        let option = &row[0];
+        let value = &row[1];
+        match option.as_str() {
+            "seed-ratio" => seed_ratio = Some(value.parse::<f32>().unwrap()),
+            "seed-time" => seed_time = Some(value.parse::<u32>().unwrap()),
+            _ => panic!("Unknown option: {}", option),
+        }
+    }
+
+    engine
+        .change_option(TaskId(id), None, None, seed_ratio, seed_time)
+        .await
+        .expect("Failed to change options");
+
+    // Give the actor thread a moment to process the command
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}
+
+#[then(expr = "the task {int} should have seed_ratio {float} and seed_time {int}")]
+async fn then_assert_task_overrides(world: &mut AuraWorld, id: u64, ratio: f32, time: u32) {
+    let engine = world.engine.as_ref().expect("Engine not running");
+    let active = engine
+        .tell_active()
+        .await
+        .expect("Failed to get active tasks");
+    let task = active
+        .iter()
+        .find(|t| t.id == TaskId(id))
+        .expect("Task not found");
+    assert_eq!(task.seed_ratio, Some(ratio));
+    assert_eq!(task.seed_time, Some(time));
+}

--- a/aura-daemon/src/jsonrpc/download.rs
+++ b/aura-daemon/src/jsonrpc/download.rs
@@ -190,8 +190,24 @@ pub async fn handle_change_option(engine: &Engine, params: Option<Value>) -> Res
         depends_on = Some(list);
     }
 
+    let seed_ratio = options.get("seed-ratio").and_then(|v| {
+        if let Some(s) = v.as_str() {
+            s.parse::<f32>().ok()
+        } else {
+            v.as_f64().map(|f| f as f32)
+        }
+    });
+
+    let seed_time = options.get("seed-time").and_then(|v| {
+        if let Some(s) = v.as_str() {
+            s.parse::<u32>().ok()
+        } else {
+            v.as_u64().map(|n| n as u32)
+        }
+    });
+
     engine
-        .change_option(id, priority, depends_on)
+        .change_option(id, priority, depends_on, seed_ratio, seed_time)
         .await
         .map_err(|e| json!({ "code": -32000, "message": e.to_string() }))?;
 


### PR DESCRIPTION
## Description

This PR implements global BitTorrent seeding limits (`min_ratio`, `max_seeding_time`, and `stop_on_either` logic) and per-task configuration overrides (`seed-ratio` and `seed-time`) via JSON-RPC. It also ensures that the CLI waits for seeding completion before clean exit.

Key enhancements include:
1. **Global Configuration**: Added `SeedingConfig` structure mapping `min_ratio`, `max_seeding_time_secs` and `stop_on_either` to the core configuration, with options fully documented in `Aura.example.toml`.
2. **Dynamic Task-level Overrides**: Exposed `seed-ratio` and `seed-time` options in `Engine::change_option` and the daemon's JSON-RPC endpoint (`handle_change_option`).
3. **Limit Evaluation Loop**: Integrated `check_seed_limits` into the orchestrator runner loop to regularly evaluate completed tasks and transition them to `Paused` once target ratios/durations are reached. Added a filter to ensure limits only apply to tasks with BitTorrent subtasks.
4. **CLI Seeding Flow**: Updated `aura-cli` to keep torrent tasks running and display `"Seeding..."` upon download completion, exiting gracefully only after receiving `Event::SeedingComplete`.
5. **Quality Improvements**: Resolved thread-local const-safety Clippy warnings and wrote unit/integration tests (`seeding_limits.feature`) validating both global configuration limits and per-task overrides.

Fixes #257

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
- [x] Any dependent changes have been merged and published in downstream modules
