### PR TITLE
chore: update Dockerfile with VPN tools and healthchecks, fix RPC binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,63 @@
 # Stage 1: Build Environment
 FROM rust:1.80-slim-bookworm AS builder
 
-# Install system dependencies required for compilation (libdbus)
+# Install system dependencies required for compilation
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libdbus-1-dev \
+    libxcb1-dev \
+    libxcb-render0-dev \
+    libxcb-shape0-dev \
+    libxcb-xfixes0-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Set up the working directory
 WORKDIR /usr/src/aura
 
-# Copy the Cargo files and workspace members
+# Copy the Cargo files and workspace members first for better caching
+COPY Cargo.toml Cargo.lock ./
+COPY aura-core/Cargo.toml aura-core/
+COPY aura-cli/Cargo.toml aura-cli/
+COPY aura-daemon/Cargo.toml aura-daemon/
+COPY aura-tui/Cargo.toml aura-tui/
+COPY aura/Cargo.toml aura/
+
+# Create dummy source files to satisfy cargo build for dependency caching
+RUN mkdir -p aura-core/src aura-cli/src aura-daemon/src aura-tui/src aura/src \
+    && touch aura-core/src/lib.rs aura-cli/src/lib.rs aura-daemon/src/lib.rs aura-tui/src/lib.rs \
+    && echo "fn main() {}" > aura/src/main.rs
+
+# We need to copy assets for aura-daemon as rust-embed requires them at compile time
+COPY aura-daemon/web/ aura-daemon/web/
+
+# Pre-build dependencies
+RUN cargo build --release -p aura
+
+# Copy the rest of the source code
 COPY . .
 
 # Build the unified binary in release mode
-RUN cargo build --release -p aura
+# We touch the main.rs to ensure the actual app is built after the dummy build
+RUN touch aura/src/main.rs && cargo build --release -p aura
 
 # Stage 2: Runtime Environment
 FROM debian:bookworm-slim
 
-# Install runtime dependencies (ca-certificates for HTTPS, libdbus-1-3 for dbus)
+# Install runtime dependencies
+# - ca-certificates for HTTPS
+# - libdbus-1-3 for dbus
+# - libxcb for TUI/clipboard
+# - wireguard-tools and iproute2 for VPN support (ADR-0038)
+# - curl for healthchecks (ADR-0051)
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libdbus-1-3 \
+    libxcb1 \
+    libxcb-render0 \
+    libxcb-shape0 \
+    libxcb-xfixes0 \
+    wireguard-tools \
+    iproute2 \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user for security
@@ -38,6 +73,10 @@ EXPOSE 6800
 
 # Provide a volume for downloads
 VOLUME ["/downloads"]
+
+# Add healthcheck to monitor the daemon (ADR-0051)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:6800/health || exit 1
 
 # Set the default entrypoint to the unified binary
 ENTRYPOINT ["aura"]

--- a/aura-daemon/src/server.rs
+++ b/aura-daemon/src/server.rs
@@ -26,7 +26,7 @@ pub async fn start_server(
         .allow_headers(tower_http::cors::Any);
 
     let app = create_router(state).layer(cors);
-    let addr = format!("127.0.0.1:{}", rpc_port);
+    let addr = format!("0.0.0.0:{}", rpc_port);
 
     if let Some((cert_path, key_path)) = tls_config {
         let rustls_config =


### PR DESCRIPTION
## Description

This PR updates the `Dockerfile` to support native VPN integration (ADR-0038) and adds health monitoring capabilities (ADR-0051). It also fixes a network binding issue in `aura-daemon` that prevented Docker access and optimizes the build process for faster rebuilds.

### Key Changes:
- **VPN Support**: Added `wireguard-tools` and `iproute2` to the runtime image.
- **Health Checks**: Added `curl` and a `HEALTHCHECK` instruction using the `/health` endpoint.
- **Docker Access**: Changed RPC server binding from `127.0.0.1` to `0.0.0.0`.
- **Build Optimization**: Implemented dependency pre-building using dummy source files and ensured asset inclusion for `rust-embed`.

Fixes # (No specific issue linked, but covers Docker and VPN deployment requirements)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
