### PR TITLE
feat: implement system service, watch folder, and RSS subscription features

### DIFF
--- a/Aura.example.toml
+++ b/Aura.example.toml
@@ -87,6 +87,7 @@ write_buffer_kb = 256                  # Size of thread-local write buffers
 memory_limit_mb = 512                  # Max RAM for write aggregation
 memory_safety_margin_mb = 50           # Reserve memory to prevent OOM
 recheck_throttle_ms = 10               # Delay in milliseconds between read chunks during hash recheck
+# watch_dir = "watch"                  # Folder to monitor for auto-ingesting .torrent/.metalink/etc. drops (ADR 0069)
 
 
 [bulk]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -272,7 +272,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -298,7 +298,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -382,9 +382,12 @@ dependencies = [
  "clap",
  "reqwest",
  "serde_json",
+ "service-manager",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
+ "windows-service",
 ]
 
 [[package]]
@@ -442,7 +445,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "reqwest",
- "rustix",
+ "rustix 1.1.4",
  "rustls 0.23.40",
  "rustls-native-certs",
  "serde",
@@ -482,6 +485,7 @@ dependencies = [
  "rand 0.10.1",
  "rcgen",
  "regex",
+ "reqwest",
  "rlimit",
  "rust-embed",
  "serde",
@@ -1428,6 +1432,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1706,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot 0.12.5",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2067,6 +2080,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2201,17 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b881ab2524b96a5ce932056c7482ba6152e2226fed3936b3e592adeb95ca6d"
+dependencies = [
+ "codepage",
+ "encoding_rs",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2558,7 +2602,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -2901,6 +2945,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3594,6 +3647,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,6 +3669,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4735,6 +4803,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.39.4",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4785,7 +4866,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4981,6 +5062,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -5316,6 +5406,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5516,6 +5617,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -5523,7 +5637,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -5867,6 +5981,22 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "service-manager"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ff6975a4ea07dda326cf122fcc1b5cf6266daad42d1442a666a99fe50f0de9"
+dependencies = [
+ "cfg-if",
+ "dirs",
+ "encoding-utils",
+ "encoding_rs",
+ "log",
+ "plist",
+ "which",
+ "xml-rs",
 ]
 
 [[package]]
@@ -6301,7 +6431,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6311,7 +6441,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -7263,6 +7393,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7442,6 +7584,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857224b3b211c6f3616921f081ee54721ee3ad2ace2fac6a6337e032f7b4dcf2"
+dependencies = [
+ "bitflags 2.13.0",
+ "widestring",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7805,7 +7958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -7909,7 +8062,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,3 +106,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = "2"
 wiremock = "0.6"
+service-manager = "0.11.0"
+windows-service = "0.8.1"
+

--- a/aura-core/src/config/storage.rs
+++ b/aura-core/src/config/storage.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct StorageConfig {
     pub download_dir: String,
     pub sandbox_root: Option<String>,
+    pub watch_dir: Option<String>,
     pub cache_size_mb: u32,
     pub preallocate: bool,
     pub allocation_mode: String, // "none", "prealloc", "falloc"
@@ -24,6 +25,7 @@ impl Default for StorageConfig {
         Self {
             download_dir: ".".to_string(),
             sandbox_root: None,
+            watch_dir: None,
             cache_size_mb: 16,
             preallocate: true,
             allocation_mode: "falloc".to_string(),

--- a/aura-core/src/lib.rs
+++ b/aura-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod orchestrator;
 pub mod peer_registry;
 pub mod piece_picker;
 pub mod power;
+pub mod rss;
 pub mod scrubber;
 pub mod storage;
 pub mod task;

--- a/aura-core/src/orchestrator/engine.rs
+++ b/aura-core/src/orchestrator/engine.rs
@@ -13,6 +13,7 @@ pub struct Engine {
     pub(crate) command_tx: mpsc::Sender<Command>,
     pub(crate) event_tx: broadcast::Sender<Event>,
     pub config: Arc<ArcSwap<crate::AuraConfig>>,
+    pub last_ingested_file: Arc<tokio::sync::Mutex<Option<String>>>,
 }
 
 impl std::fmt::Debug for Engine {
@@ -29,6 +30,7 @@ impl super::traits::EventSubscriber for Engine {
 
 impl Engine {
     pub async fn new(config: crate::AuraConfig) -> Result<(Self, Orchestrator, StorageEngine)> {
+        let last_ingested_file = Arc::new(tokio::sync::Mutex::new(None));
         let (command_tx, command_rx) = mpsc::channel(config.limits.command_channel_capacity);
         let (storage_tx, storage_rx) = mpsc::channel(config.limits.storage_channel_capacity);
         let (completion_tx, completion_rx) =
@@ -173,6 +175,7 @@ impl Engine {
                 let command_tx_watcher = command_tx.clone();
                 let config_watcher = config.clone();
                 let event_tx_watcher = event_tx.clone();
+                let last_ingested_watcher = last_ingested_file.clone();
 
                 tokio::spawn(async move {
                     use notify::{EventKind, RecursiveMode, Watcher};
@@ -202,6 +205,7 @@ impl Engine {
                         command_tx: command_tx_watcher,
                         event_tx: event_tx_watcher,
                         config: config_watcher,
+                        last_ingested_file: last_ingested_watcher,
                     };
 
                     while let Some(path) = rx.recv().await {
@@ -212,8 +216,26 @@ impl Engine {
                             }
                         }
 
-                        // Debounce logic: wait 1 second for write completion
-                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        // Debounce logic: wait for file size to stabilize
+                        let mut last_size = 0;
+                        let mut stable_count = 0;
+                        loop {
+                            tokio::time::sleep(Duration::from_millis(500)).await;
+                            if let Ok(metadata) = std::fs::metadata(&path) {
+                                let current_size = metadata.len();
+                                if current_size > 0 && current_size == last_size {
+                                    stable_count += 1;
+                                    if stable_count >= 2 {
+                                        break; // Stabilized for 1 second (two 500ms intervals)
+                                    }
+                                } else {
+                                    stable_count = 0;
+                                }
+                                last_size = current_size;
+                            } else {
+                                break;
+                            }
+                        }
 
                         if !path.exists() {
                             continue;
@@ -300,6 +322,7 @@ impl Engine {
                 command_tx,
                 event_tx,
                 config,
+                last_ingested_file,
             },
             orchestrator,
             storage,

--- a/aura-core/src/orchestrator/engine.rs
+++ b/aura-core/src/orchestrator/engine.rs
@@ -6,7 +6,7 @@ use arc_swap::ArcSwap;
 use rand::RngExt;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 #[derive(Clone)]
 pub struct Engine {
@@ -166,6 +166,135 @@ impl Engine {
             }
         }
 
+        // Setup watch directory watcher
+        if let Some(ref watch_dir_str) = initial_config.storage.watch_dir {
+            let watch_dir_path = std::path::PathBuf::from(watch_dir_str);
+            if watch_dir_path.exists() {
+                let command_tx_watcher = command_tx.clone();
+                let config_watcher = config.clone();
+                let event_tx_watcher = event_tx.clone();
+
+                tokio::spawn(async move {
+                    use notify::{EventKind, RecursiveMode, Watcher};
+                    use std::time::Duration;
+
+                    let (tx, mut rx) = mpsc::channel(100);
+                    let mut watcher =
+                        notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+                            if let Ok(event) = res {
+                                if matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_))
+                                {
+                                    for path in event.paths {
+                                        let _ = tx.blocking_send(path);
+                                    }
+                                }
+                            }
+                        })
+                        .expect("Failed to create watch directory watcher");
+
+                    watcher
+                        .watch(&watch_dir_path, RecursiveMode::NonRecursive)
+                        .expect("Failed to watch watch directory");
+
+                    info!("Watch folder monitoring enabled at {:?}", watch_dir_path);
+
+                    let engine_instance = Self {
+                        command_tx: command_tx_watcher,
+                        event_tx: event_tx_watcher,
+                        config: config_watcher,
+                    };
+
+                    while let Some(path) = rx.recv().await {
+                        // Skip if it's already in processed or failed folders
+                        if let Some(parent) = path.parent() {
+                            if parent.ends_with("processed") || parent.ends_with("failed") {
+                                continue;
+                            }
+                        }
+
+                        // Debounce logic: wait 1 second for write completion
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+
+                        if !path.exists() {
+                            continue;
+                        }
+
+                        let ext = path
+                            .extension()
+                            .and_then(|e| e.to_str())
+                            .unwrap_or("")
+                            .to_lowercase();
+
+                        if ext != "torrent" && ext != "metalink" && ext != "meta4" && ext != "nzb" {
+                            continue;
+                        }
+
+                        info!("Watch folder: detected file {:?}", path);
+
+                        let result =
+                            crate::orchestrator::watch::ingest_watch_file(&engine_instance, &path)
+                                .await;
+
+                        let file_name = match path.file_name() {
+                            Some(f) => f,
+                            None => continue,
+                        };
+
+                        let mut move_or_delete_failed = false;
+                        let mut final_err = None;
+
+                        if result.is_ok() {
+                            let dest_dir = watch_dir_path.join("processed");
+                            let _ = std::fs::create_dir_all(&dest_dir);
+                            let dest_path = dest_dir.join(file_name);
+                            if let Err(e) = std::fs::rename(&path, &dest_path) {
+                                warn!(
+                                    "Watch folder: failed to move {:?} to processed folder: {}",
+                                    path, e
+                                );
+                                if let Err(e2) = std::fs::remove_file(&path) {
+                                    move_or_delete_failed = true;
+                                    final_err = Some(e2);
+                                }
+                            } else {
+                                info!("Watch folder: moved {:?} to processed folder", file_name);
+                            }
+                        } else {
+                            let err_msg = result.err().unwrap();
+                            warn!(
+                                "Watch folder ingestion failed for {:?}: {}",
+                                file_name, err_msg
+                            );
+                            let dest_dir = watch_dir_path.join("failed");
+                            let _ = std::fs::create_dir_all(&dest_dir);
+                            let dest_path = dest_dir.join(file_name);
+                            if let Err(e) = std::fs::rename(&path, &dest_path) {
+                                warn!(
+                                    "Watch folder: failed to move {:?} to failed folder: {}",
+                                    path, e
+                                );
+                                if let Err(e2) = std::fs::remove_file(&path) {
+                                    move_or_delete_failed = true;
+                                    final_err = Some(e2);
+                                }
+                            }
+                        }
+
+                        if move_or_delete_failed {
+                            error!(
+                                "Watch folder: permission error. Cannot move or delete file {:?}. \
+                                Disabling watch folder watcher to prevent infinite loops. Error: {:?}",
+                                path, final_err
+                            );
+                            break;
+                        }
+                    }
+
+                    drop(watcher);
+                });
+            }
+        }
+
         Ok((
             Self {
                 command_tx,
@@ -177,3 +306,7 @@ impl Engine {
         ))
     }
 }
+
+#[cfg(test)]
+#[path = "engine_tests.rs"]
+mod tests;

--- a/aura-core/src/orchestrator/engine_tests.rs
+++ b/aura-core/src/orchestrator/engine_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+use std::fs;
+
+#[tokio::test]
+async fn test_ingest_watch_file_non_existent() {
+    let mut config = crate::AuraConfig::default();
+    let temp_dir = tempfile::tempdir().unwrap();
+    config.storage.download_dir = temp_dir.path().to_string_lossy().into_owned();
+    let (engine, _orch, _store) = Engine::new(config).await.unwrap();
+
+    let path = std::path::Path::new("non_existent_file.torrent");
+    let result = crate::orchestrator::watch::ingest_watch_file(&engine, path).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("metadata"));
+}
+
+#[tokio::test]
+async fn test_ingest_watch_file_empty() {
+    let mut config = crate::AuraConfig::default();
+    let temp_dir = tempfile::tempdir().unwrap();
+    config.storage.download_dir = temp_dir.path().to_string_lossy().into_owned();
+    let (engine, _orch, _store) = Engine::new(config).await.unwrap();
+
+    let temp_dir_files = tempfile::tempdir().unwrap();
+    let path = temp_dir_files.path().join("empty.torrent");
+    fs::write(&path, "").unwrap();
+
+    let result = crate::orchestrator::watch::ingest_watch_file(&engine, &path).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("empty"));
+}

--- a/aura-core/src/orchestrator/mod.rs
+++ b/aura-core/src/orchestrator/mod.rs
@@ -21,6 +21,7 @@ pub mod task_handle;
 pub mod telemetry;
 pub mod traits;
 pub mod vpn_enforcement;
+pub mod watch;
 pub mod worker_command;
 
 pub use command::Command;

--- a/aura-core/src/orchestrator/watch.rs
+++ b/aura-core/src/orchestrator/watch.rs
@@ -47,7 +47,13 @@ pub async fn ingest_watch_file(
     };
 
     match engine.add_task_with_options(args).await {
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            {
+                let mut guard = engine.last_ingested_file.lock().await;
+                *guard = Some(file_name.to_string());
+            }
+            Ok(())
+        }
         Err(crate::Error::DuplicateTask(_)) => {
             warn!("Watch folder: task already exists for {:?}", file_name);
             Ok(())

--- a/aura-core/src/orchestrator/watch.rs
+++ b/aura-core/src/orchestrator/watch.rs
@@ -1,0 +1,57 @@
+use crate::orchestrator::Engine;
+use tracing::warn;
+
+pub async fn ingest_watch_file(
+    engine: &Engine,
+    path: &std::path::Path,
+) -> std::result::Result<(), String> {
+    let file_name = path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .ok_or_else(|| "Invalid file name".to_string())?;
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    let metadata =
+        std::fs::metadata(path).map_err(|e| format!("Failed to read metadata: {}", e))?;
+    if metadata.len() == 0 {
+        return Err("File is empty".to_string());
+    }
+
+    let task_id = crate::TaskId::random();
+
+    let ttype = match ext.as_str() {
+        "torrent" => crate::task::TaskType::BitTorrent,
+        _ => crate::task::TaskType::Http,
+    };
+
+    let abs_path =
+        std::fs::canonicalize(path).map_err(|e| format!("Failed to canonicalize path: {}", e))?;
+    let uri = abs_path.to_string_lossy().to_string();
+    let sources = vec![(uri, ttype)];
+
+    let args = crate::orchestrator::command::AddTaskArgs {
+        id: task_id,
+        tenant_id: None,
+        name: file_name.to_string(),
+        sources,
+        checksum: None,
+        priority: 3,
+        streaming_mode: false,
+        depends_on: Vec::new(),
+        follow_on: None,
+    };
+
+    match engine.add_task_with_options(args).await {
+        Ok(_) => Ok(()),
+        Err(crate::Error::DuplicateTask(_)) => {
+            warn!("Watch folder: task already exists for {:?}", file_name);
+            Ok(())
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}

--- a/aura-core/src/rss/manager.rs
+++ b/aura-core/src/rss/manager.rs
@@ -9,6 +9,8 @@ pub struct FeedSubscription {
     pub name: String,
     pub poll_interval: Option<u64>, // Polling frequency in minutes, default: 30
     pub filters: Option<Vec<String>>,
+    pub categories: Option<Vec<String>>,
+    pub max_size: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -104,24 +106,70 @@ impl RssManager {
         Ok(())
     }
 
-    pub fn matches_filters(title: &str, filters: &Option<Vec<String>>) -> bool {
+    pub fn matches_filters(
+        title: &str,
+        category: Option<&str>,
+        size: Option<u64>,
+        filters: &Option<Vec<String>>,
+        categories: &Option<Vec<String>>,
+        max_size: Option<u64>,
+    ) -> bool {
+        // 1. Check title filters
         if let Some(ref list) = filters {
-            if list.is_empty() {
-                return true;
-            }
-            for pattern in list {
-                if let Ok(re) = regex::Regex::new(pattern) {
-                    if re.is_match(title) {
-                        return true;
+            if !list.is_empty() {
+                let mut matched = false;
+                for pattern in list {
+                    if let Ok(re) = regex::Regex::new(pattern) {
+                        if re.is_match(title) {
+                            matched = true;
+                            break;
+                        }
+                    } else if title.contains(pattern) {
+                        matched = true;
+                        break;
                     }
-                } else if title.contains(pattern) {
-                    return true;
+                }
+                if !matched {
+                    return false;
                 }
             }
-            false
-        } else {
-            true
         }
+
+        // 2. Check category filters
+        if let Some(ref cat_list) = categories {
+            if !cat_list.is_empty() {
+                if let Some(cat) = category {
+                    let mut matched = false;
+                    for pattern in cat_list {
+                        if let Ok(re) = regex::Regex::new(pattern) {
+                            if re.is_match(cat) {
+                                matched = true;
+                                break;
+                            }
+                        } else if cat.contains(pattern) {
+                            matched = true;
+                            break;
+                        }
+                    }
+                    if !matched {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        // 3. Check max size limit
+        if let Some(limit) = max_size {
+            if let Some(sz) = size {
+                if sz > limit {
+                    return false;
+                }
+            }
+        }
+
+        true
     }
 }
 

--- a/aura-core/src/rss/manager.rs
+++ b/aura-core/src/rss/manager.rs
@@ -1,0 +1,130 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeedSubscription {
+    pub url: String,
+    pub name: String,
+    pub poll_interval: Option<u64>, // Polling frequency in minutes, default: 30
+    pub filters: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct FeedsToml {
+    #[serde(default)]
+    pub feeds: Vec<FeedSubscription>,
+}
+
+pub struct RssManager {
+    feeds_path: PathBuf,
+    history_path: PathBuf,
+}
+
+impl Default for RssManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RssManager {
+    pub fn new() -> Self {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let aura_dir = home.join(".aura");
+        let _ = fs::create_dir_all(&aura_dir);
+
+        Self {
+            feeds_path: aura_dir.join("feeds.toml"),
+            history_path: aura_dir.join("feed_history.txt"),
+        }
+    }
+
+    pub fn load_subscriptions(&self) -> Result<Vec<FeedSubscription>, String> {
+        if !self.feeds_path.exists() {
+            return Ok(Vec::new());
+        }
+        let content = fs::read_to_string(&self.feeds_path)
+            .map_err(|e| format!("Failed to read feeds file: {}", e))?;
+        let toml_data: FeedsToml =
+            toml::from_str(&content).map_err(|e| format!("Failed to parse feeds TOML: {}", e))?;
+        Ok(toml_data.feeds)
+    }
+
+    pub fn save_subscriptions(&self, feeds: Vec<FeedSubscription>) -> Result<(), String> {
+        let toml_data = FeedsToml { feeds };
+        let content = toml::to_string_pretty(&toml_data)
+            .map_err(|e| format!("Failed to serialize feeds to TOML: {}", e))?;
+        fs::write(&self.feeds_path, content)
+            .map_err(|e| format!("Failed to write feeds file: {}", e))?;
+        Ok(())
+    }
+
+    pub fn add_subscription(&self, sub: FeedSubscription) -> Result<(), String> {
+        let mut subs = self.load_subscriptions()?;
+        if subs.iter().any(|s| s.url == sub.url || s.name == sub.name) {
+            return Err("Subscription with this URL or Name already exists".to_string());
+        }
+        subs.push(sub);
+        self.save_subscriptions(subs)
+    }
+
+    pub fn remove_subscription(&self, name_or_url: &str) -> Result<(), String> {
+        let mut subs = self.load_subscriptions()?;
+        let original_len = subs.len();
+        subs.retain(|s| s.name != name_or_url && s.url != name_or_url);
+        if subs.len() == original_len {
+            return Err("Subscription not found".to_string());
+        }
+        self.save_subscriptions(subs)
+    }
+
+    pub fn is_ingested(&self, guid: &str) -> bool {
+        if !self.history_path.exists() {
+            return false;
+        }
+        if let Ok(content) = fs::read_to_string(&self.history_path) {
+            content.lines().any(|line| line.trim() == guid)
+        } else {
+            false
+        }
+    }
+
+    pub fn mark_ingested(&self, guid: &str) -> Result<(), String> {
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.history_path)
+            .map_err(|e| format!("Failed to open history file: {}", e))?;
+        writeln!(file, "{}", guid)
+            .map_err(|e| format!("Failed to write to history file: {}", e))?;
+        Ok(())
+    }
+
+    pub fn matches_filters(title: &str, filters: &Option<Vec<String>>) -> bool {
+        if let Some(ref list) = filters {
+            if list.is_empty() {
+                return true;
+            }
+            for pattern in list {
+                if let Ok(re) = regex::Regex::new(pattern) {
+                    if re.is_match(title) {
+                        return true;
+                    }
+                } else if title.contains(pattern) {
+                    return true;
+                }
+            }
+            false
+        } else {
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "manager_tests.rs"]
+mod tests;

--- a/aura-core/src/rss/manager_tests.rs
+++ b/aura-core/src/rss/manager_tests.rs
@@ -5,28 +5,110 @@ fn test_matches_filters() {
     // Empty filters match everything
     assert!(RssManager::matches_filters(
         "Aura v1.0.0 Stable Release",
-        &None
+        None,
+        None,
+        &None,
+        &None,
+        None
     ));
     assert!(RssManager::matches_filters(
         "Aura v1.0.0 Stable Release",
-        &Some(vec![])
+        None,
+        None,
+        &Some(vec![]),
+        &None,
+        None
     ));
 
-    // Matching filters
+    // Matching title filters
     let filters = Some(vec!["Stable".to_string(), r"v\d+\.\d+\.\d+".to_string()]);
     assert!(RssManager::matches_filters(
         "Aura v1.0.0 Stable Release",
-        &filters
+        None,
+        None,
+        &filters,
+        &None,
+        None
     ));
-    assert!(!RssManager::matches_filters("Aura Patch Release", &filters));
-    assert!(!RssManager::matches_filters("Aura Beta Release", &filters));
+    assert!(!RssManager::matches_filters(
+        "Aura Patch Release",
+        None,
+        None,
+        &filters,
+        &None,
+        None
+    ));
+    assert!(!RssManager::matches_filters(
+        "Aura Beta Release",
+        None,
+        None,
+        &filters,
+        &None,
+        None
+    ));
 
     // Regex specific match
     let regex_filters = Some(vec![r"^Aura.*Stable$".to_string()]);
-    assert!(RssManager::matches_filters("Aura Stable", &regex_filters));
+    assert!(RssManager::matches_filters(
+        "Aura Stable",
+        None,
+        None,
+        &regex_filters,
+        &None,
+        None
+    ));
     assert!(!RssManager::matches_filters(
         "Aura Stable Release",
-        &regex_filters
+        None,
+        None,
+        &regex_filters,
+        &None,
+        None
+    ));
+
+    // Category filtering
+    let categories = Some(vec!["anime".to_string(), "movie".to_string()]);
+    assert!(RssManager::matches_filters(
+        "Aura v1.0.0",
+        Some("anime"),
+        None,
+        &None,
+        &categories,
+        None
+    ));
+    assert!(!RssManager::matches_filters(
+        "Aura v1.0.0",
+        Some("software"),
+        None,
+        &None,
+        &categories,
+        None
+    ));
+    assert!(!RssManager::matches_filters(
+        "Aura v1.0.0",
+        None,
+        None,
+        &None,
+        &categories,
+        None
+    ));
+
+    // Max size filtering
+    assert!(RssManager::matches_filters(
+        "Aura v1.0.0",
+        None,
+        Some(1000),
+        &None,
+        &None,
+        Some(2000)
+    ));
+    assert!(!RssManager::matches_filters(
+        "Aura v1.0.0",
+        None,
+        Some(3000),
+        &None,
+        &None,
+        Some(2000)
     ));
 }
 
@@ -51,6 +133,8 @@ fn test_manager_subscriptions() {
         name: "Example Feed".to_string(),
         poll_interval: Some(15),
         filters: Some(vec!["Aura".to_string()]),
+        categories: None,
+        max_size: None,
     };
     manager.add_subscription(sub.clone()).unwrap();
 

--- a/aura-core/src/rss/manager_tests.rs
+++ b/aura-core/src/rss/manager_tests.rs
@@ -1,0 +1,76 @@
+use super::*;
+
+#[test]
+fn test_matches_filters() {
+    // Empty filters match everything
+    assert!(RssManager::matches_filters(
+        "Aura v1.0.0 Stable Release",
+        &None
+    ));
+    assert!(RssManager::matches_filters(
+        "Aura v1.0.0 Stable Release",
+        &Some(vec![])
+    ));
+
+    // Matching filters
+    let filters = Some(vec!["Stable".to_string(), r"v\d+\.\d+\.\d+".to_string()]);
+    assert!(RssManager::matches_filters(
+        "Aura v1.0.0 Stable Release",
+        &filters
+    ));
+    assert!(!RssManager::matches_filters("Aura Patch Release", &filters));
+    assert!(!RssManager::matches_filters("Aura Beta Release", &filters));
+
+    // Regex specific match
+    let regex_filters = Some(vec![r"^Aura.*Stable$".to_string()]);
+    assert!(RssManager::matches_filters("Aura Stable", &regex_filters));
+    assert!(!RssManager::matches_filters(
+        "Aura Stable Release",
+        &regex_filters
+    ));
+}
+
+#[test]
+fn test_manager_subscriptions() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let feeds_path = temp_dir.path().join("feeds.toml");
+    let history_path = temp_dir.path().join("feed_history.txt");
+
+    let manager = RssManager {
+        feeds_path: feeds_path.clone(),
+        history_path: history_path.clone(),
+    };
+
+    // Load empty subscriptions
+    let subs = manager.load_subscriptions().unwrap();
+    assert!(subs.is_empty());
+
+    // Add subscription
+    let sub = FeedSubscription {
+        url: "https://example.com/rss".to_string(),
+        name: "Example Feed".to_string(),
+        poll_interval: Some(15),
+        filters: Some(vec!["Aura".to_string()]),
+    };
+    manager.add_subscription(sub.clone()).unwrap();
+
+    // Verify duplicate error
+    assert!(manager.add_subscription(sub).is_err());
+
+    // Load and check
+    let subs = manager.load_subscriptions().unwrap();
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs[0].name, "Example Feed");
+    assert_eq!(subs[0].url, "https://example.com/rss");
+    assert_eq!(subs[0].poll_interval, Some(15));
+
+    // Test mark and check ingested
+    assert!(!manager.is_ingested("guid-123"));
+    manager.mark_ingested("guid-123").unwrap();
+    assert!(manager.is_ingested("guid-123"));
+
+    // Remove subscription
+    manager.remove_subscription("Example Feed").unwrap();
+    let subs = manager.load_subscriptions().unwrap();
+    assert!(subs.is_empty());
+}

--- a/aura-core/src/rss/mod.rs
+++ b/aura-core/src/rss/mod.rs
@@ -1,0 +1,5 @@
+pub mod manager;
+pub mod parser;
+
+pub use manager::{FeedSubscription, RssManager};
+pub use parser::{parse_feed, FeedItem};

--- a/aura-core/src/rss/parser.rs
+++ b/aura-core/src/rss/parser.rs
@@ -115,55 +115,47 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
             Ok(Event::End(ref e)) => {
                 let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
                 match state {
-                    State::Item => {
-                        if tag == "item" {
-                            state = State::Channel;
-                            if current_guid.is_empty() {
-                                let hash_input = if !current_pubdate.is_empty() {
-                                    format!("{}{}", current_title, current_pubdate)
-                                } else {
-                                    format!("{}{}", current_title, current_link)
-                                };
-                                current_guid = compute_md5_hex(&hash_input);
-                            }
-                            if !current_link.is_empty() {
-                                items.push(FeedItem {
-                                    title: current_title.clone(),
-                                    link: current_link.clone(),
-                                    guid: current_guid.clone(),
-                                });
-                            }
+                    State::Item if tag == "item" => {
+                        state = State::Channel;
+                        if current_guid.is_empty() {
+                            let hash_input = if !current_pubdate.is_empty() {
+                                format!("{}{}", current_title, current_pubdate)
+                            } else {
+                                format!("{}{}", current_title, current_link)
+                            };
+                            current_guid = compute_md5_hex(&hash_input);
+                        }
+                        if !current_link.is_empty() {
+                            items.push(FeedItem {
+                                title: current_title.clone(),
+                                link: current_link.clone(),
+                                guid: current_guid.clone(),
+                            });
                         }
                     }
-                    State::Entry => {
-                        if tag == "entry" {
-                            state = State::Feed;
-                            if current_guid.is_empty() {
-                                let hash_input = if !current_pubdate.is_empty() {
-                                    format!("{}{}", current_title, current_pubdate)
-                                } else {
-                                    format!("{}{}", current_title, current_link)
-                                };
-                                current_guid = compute_md5_hex(&hash_input);
-                            }
-                            if !current_link.is_empty() {
-                                items.push(FeedItem {
-                                    title: current_title.clone(),
-                                    link: current_link.clone(),
-                                    guid: current_guid.clone(),
-                                });
-                            }
+                    State::Entry if tag == "entry" => {
+                        state = State::Feed;
+                        if current_guid.is_empty() {
+                            let hash_input = if !current_pubdate.is_empty() {
+                                format!("{}{}", current_title, current_pubdate)
+                            } else {
+                                format!("{}{}", current_title, current_link)
+                            };
+                            current_guid = compute_md5_hex(&hash_input);
+                        }
+                        if !current_link.is_empty() {
+                            items.push(FeedItem {
+                                title: current_title.clone(),
+                                link: current_link.clone(),
+                                guid: current_guid.clone(),
+                            });
                         }
                     }
-                    State::Channel => {
-                        if tag == "channel" {
-                            state = State::Root;
-                        }
+                    State::Channel if tag == "channel" => {
+                        state = State::Root;
                     }
-                    State::Feed => {
-                        if tag == "feed" {
-                            state = State::Root;
-                        }
+                    State::Feed if tag == "feed" => {
+                        state = State::Root;
                     }
                     _ => {}
                 }

--- a/aura-core/src/rss/parser.rs
+++ b/aura-core/src/rss/parser.rs
@@ -7,6 +7,8 @@ pub struct FeedItem {
     pub title: String,
     pub link: String,
     pub guid: String,
+    pub category: Option<String>,
+    pub size: Option<u64>,
 }
 
 fn compute_md5_hex(s: &str) -> String {
@@ -19,6 +21,8 @@ fn compute_md5_hex(s: &str) -> String {
 pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
     let mut reader = Reader::from_reader(data);
     reader.config_mut().trim_text(true);
+    // Entity expansion is disabled by default in quick-xml (resolve_entities is false),
+    // protecting against XML entity expansion attacks (billion laughs).
 
     let mut buf = Vec::new();
     let mut items = Vec::new();
@@ -38,6 +42,8 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
     let mut current_guid = String::new();
     let mut current_pubdate = String::new();
     let mut current_tag = String::new();
+    let mut current_category: Option<String> = None;
+    let mut current_size: Option<u64> = None;
 
     loop {
         match reader.read_event_into(&mut buf) {
@@ -58,6 +64,8 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
                             current_link.clear();
                             current_guid.clear();
                             current_pubdate.clear();
+                            current_category = None;
+                            current_size = None;
                         }
                     }
                     State::Feed => {
@@ -67,6 +75,8 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
                             current_link.clear();
                             current_guid.clear();
                             current_pubdate.clear();
+                            current_category = None;
+                            current_size = None;
                         }
                     }
                     State::Item | State::Entry => {
@@ -80,6 +90,12 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
                             for attr in e.attributes().flatten() {
                                 if attr.key.as_ref() == b"url" {
                                     current_link = String::from_utf8_lossy(&attr.value).to_string();
+                                } else if attr.key.as_ref() == b"length" {
+                                    if let Ok(sz_str) = std::str::from_utf8(&attr.value) {
+                                        if let Ok(sz) = sz_str.parse::<u64>() {
+                                            current_size = Some(sz);
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -101,12 +117,14 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
                         }
                         "guid" => current_guid = text,
                         "pubDate" => current_pubdate = text,
+                        "category" => current_category = Some(text),
                         _ => {}
                     },
                     State::Entry => match current_tag.as_str() {
                         "title" => current_title = text,
                         "id" => current_guid = text,
                         "published" | "updated" => current_pubdate = text,
+                        "category" => current_category = Some(text),
                         _ => {}
                     },
                     _ => {}
@@ -130,6 +148,8 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
                                 title: current_title.clone(),
                                 link: current_link.clone(),
                                 guid: current_guid.clone(),
+                                category: current_category.clone(),
+                                size: current_size,
                             });
                         }
                     }
@@ -148,6 +168,8 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
                                 title: current_title.clone(),
                                 link: current_link.clone(),
                                 guid: current_guid.clone(),
+                                category: current_category.clone(),
+                                size: current_size,
                             });
                         }
                     }
@@ -175,6 +197,12 @@ pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
                             for attr in e.attributes().flatten() {
                                 if attr.key.as_ref() == b"url" {
                                     current_link = String::from_utf8_lossy(&attr.value).to_string();
+                                } else if attr.key.as_ref() == b"length" {
+                                    if let Ok(sz_str) = std::str::from_utf8(&attr.value) {
+                                        if let Ok(sz) = sz_str.parse::<u64>() {
+                                            current_size = Some(sz);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/aura-core/src/rss/parser.rs
+++ b/aura-core/src/rss/parser.rs
@@ -1,0 +1,204 @@
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use std::io::BufRead;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct FeedItem {
+    pub title: String,
+    pub link: String,
+    pub guid: String,
+}
+
+fn compute_md5_hex(s: &str) -> String {
+    use md5::{Digest, Md5};
+    let mut hasher = Md5::new();
+    hasher.update(s.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+pub fn parse_feed<R: BufRead>(data: R) -> Result<Vec<FeedItem>, String> {
+    let mut reader = Reader::from_reader(data);
+    reader.config_mut().trim_text(true);
+
+    let mut buf = Vec::new();
+    let mut items = Vec::new();
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum State {
+        Root,
+        Channel,
+        Item,
+        Feed,
+        Entry,
+    }
+
+    let mut state = State::Root;
+    let mut current_title = String::new();
+    let mut current_link = String::new();
+    let mut current_guid = String::new();
+    let mut current_pubdate = String::new();
+    let mut current_tag = String::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                current_tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                match state {
+                    State::Root => {
+                        if current_tag == "channel" {
+                            state = State::Channel;
+                        } else if current_tag == "feed" {
+                            state = State::Feed;
+                        }
+                    }
+                    State::Channel => {
+                        if current_tag == "item" {
+                            state = State::Item;
+                            current_title.clear();
+                            current_link.clear();
+                            current_guid.clear();
+                            current_pubdate.clear();
+                        }
+                    }
+                    State::Feed => {
+                        if current_tag == "entry" {
+                            state = State::Entry;
+                            current_title.clear();
+                            current_link.clear();
+                            current_guid.clear();
+                            current_pubdate.clear();
+                        }
+                    }
+                    State::Item | State::Entry => {
+                        if current_tag == "link" {
+                            for attr in e.attributes().flatten() {
+                                if attr.key.as_ref() == b"href" {
+                                    current_link = String::from_utf8_lossy(&attr.value).to_string();
+                                }
+                            }
+                        } else if current_tag == "enclosure" {
+                            for attr in e.attributes().flatten() {
+                                if attr.key.as_ref() == b"url" {
+                                    current_link = String::from_utf8_lossy(&attr.value).to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(Event::Text(ref e)) => {
+                let text = String::from_utf8_lossy(e.as_ref()).to_string();
+                if text.is_empty() {
+                    continue;
+                }
+                match state {
+                    State::Item => match current_tag.as_str() {
+                        "title" => current_title = text,
+                        "link" => {
+                            if current_link.is_empty() {
+                                current_link = text;
+                            }
+                        }
+                        "guid" => current_guid = text,
+                        "pubDate" => current_pubdate = text,
+                        _ => {}
+                    },
+                    State::Entry => match current_tag.as_str() {
+                        "title" => current_title = text,
+                        "id" => current_guid = text,
+                        "published" | "updated" => current_pubdate = text,
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                match state {
+                    State::Item => {
+                        if tag == "item" {
+                            state = State::Channel;
+                            if current_guid.is_empty() {
+                                let hash_input = if !current_pubdate.is_empty() {
+                                    format!("{}{}", current_title, current_pubdate)
+                                } else {
+                                    format!("{}{}", current_title, current_link)
+                                };
+                                current_guid = compute_md5_hex(&hash_input);
+                            }
+                            if !current_link.is_empty() {
+                                items.push(FeedItem {
+                                    title: current_title.clone(),
+                                    link: current_link.clone(),
+                                    guid: current_guid.clone(),
+                                });
+                            }
+                        }
+                    }
+                    State::Entry => {
+                        if tag == "entry" {
+                            state = State::Feed;
+                            if current_guid.is_empty() {
+                                let hash_input = if !current_pubdate.is_empty() {
+                                    format!("{}{}", current_title, current_pubdate)
+                                } else {
+                                    format!("{}{}", current_title, current_link)
+                                };
+                                current_guid = compute_md5_hex(&hash_input);
+                            }
+                            if !current_link.is_empty() {
+                                items.push(FeedItem {
+                                    title: current_title.clone(),
+                                    link: current_link.clone(),
+                                    guid: current_guid.clone(),
+                                });
+                            }
+                        }
+                    }
+                    State::Channel => {
+                        if tag == "channel" {
+                            state = State::Root;
+                        }
+                    }
+                    State::Feed => {
+                        if tag == "feed" {
+                            state = State::Root;
+                        }
+                    }
+                    _ => {}
+                }
+                current_tag.clear();
+            }
+            Ok(Event::Empty(ref e)) => {
+                let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                match state {
+                    State::Item | State::Entry => {
+                        if tag_name == "link" {
+                            for attr in e.attributes().flatten() {
+                                if attr.key.as_ref() == b"href" {
+                                    current_link = String::from_utf8_lossy(&attr.value).to_string();
+                                }
+                            }
+                        } else if tag_name == "enclosure" {
+                            for attr in e.attributes().flatten() {
+                                if attr.key.as_ref() == b"url" {
+                                    current_link = String::from_utf8_lossy(&attr.value).to_string();
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(format!("Feed XML parse error: {}", e)),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(items)
+}
+#[cfg(test)]
+#[path = "parser_tests.rs"]
+mod tests;

--- a/aura-core/src/rss/parser_tests.rs
+++ b/aura-core/src/rss/parser_tests.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[test]
+fn test_parse_rss_feed() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+    <title>Aura releases</title>
+    <link>https://github.com/ronmkr/aura</link>
+    <description>Aura release channel</description>
+    <item>
+        <title>Aura v1.0.0 Stable</title>
+        <link>https://github.com/ronmkr/aura/releases/download/v1.0.0/aura</link>
+        <guid>v1.0.0-stable</guid>
+        <pubDate>Thu, 11 Jun 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+        <title>Aura v1.0.1 Patch</title>
+        <enclosure url="https://github.com/ronmkr/aura/releases/download/v1.0.1/aura.torrent" type="application/x-bittorrent" />
+        <pubDate>Fri, 12 Jun 2026 12:00:00 GMT</pubDate>
+    </item>
+</channel>
+</rss>"#;
+
+    let items = parse_feed(xml.as_bytes()).unwrap();
+    assert_eq!(items.len(), 2);
+
+    assert_eq!(items[0].title, "Aura v1.0.0 Stable");
+    assert_eq!(
+        items[0].link,
+        "https://github.com/ronmkr/aura/releases/download/v1.0.0/aura"
+    );
+    assert_eq!(items[0].guid, "v1.0.0-stable");
+
+    assert_eq!(items[1].title, "Aura v1.0.1 Patch");
+    assert_eq!(
+        items[1].link,
+        "https://github.com/ronmkr/aura/releases/download/v1.0.1/aura.torrent"
+    );
+    // Hashed GUID fallback because no explicit <guid> is present
+    assert!(!items[1].guid.is_empty());
+    assert_ne!(items[1].guid, "v1.0.0-stable");
+}
+
+#[test]
+fn test_parse_atom_feed() {
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>Aura Atom Feed</title>
+    <link href="http://example.org/feed/"/>
+    <updated>2026-06-11T12:00:00Z</updated>
+    <entry>
+        <title>Aura Alpha Build</title>
+        <link href="http://example.org/downloads/aura-alpha.zip"/>
+        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+        <updated>2026-06-11T12:00:00Z</updated>
+    </entry>
+</feed>"#;
+
+    let items = parse_feed(xml.as_bytes()).unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].title, "Aura Alpha Build");
+    assert_eq!(items[0].link, "http://example.org/downloads/aura-alpha.zip");
+    assert_eq!(
+        items[0].guid,
+        "urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a"
+    );
+}
+
+#[test]
+fn test_billion_laughs_prevention() {
+    // A standard entity expansion block to verify quick-xml parses safely without expanding recursively
+    let xml = r#"<?xml version="1.0"?>
+<!DOCTYPE lolz [
+ <!ENTITY lol "lol">
+ <!ELEMENT lolz (#PCDATA)>
+ <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+]>
+<rss version="2.0">
+<channel>
+    <item>
+        <title>Test &lol1;</title>
+        <link>http://example.com/test</link>
+    </item>
+</channel>
+</rss>"#;
+
+    // It should parse safely and not crash, resolving to unexpanded text (or empty/failed entity resolution)
+    let items = parse_feed(xml.as_bytes()).unwrap();
+    assert_eq!(items.len(), 1);
+    // Entity is not expanded since we did not configure custom entity resolvers.
+    assert!(items[0].title.contains("Test") || items[0].title.contains("lol"));
+}

--- a/aura-core/src/rss/parser_tests.rs
+++ b/aura-core/src/rss/parser_tests.rs
@@ -12,11 +12,12 @@ fn test_parse_rss_feed() {
         <title>Aura v1.0.0 Stable</title>
         <link>https://github.com/ronmkr/aura/releases/download/v1.0.0/aura</link>
         <guid>v1.0.0-stable</guid>
+        <category>software</category>
         <pubDate>Thu, 11 Jun 2026 12:00:00 GMT</pubDate>
     </item>
     <item>
         <title>Aura v1.0.1 Patch</title>
-        <enclosure url="https://github.com/ronmkr/aura/releases/download/v1.0.1/aura.torrent" type="application/x-bittorrent" />
+        <enclosure url="https://github.com/ronmkr/aura/releases/download/v1.0.1/aura.torrent" length="12345" type="application/x-bittorrent" />
         <pubDate>Fri, 12 Jun 2026 12:00:00 GMT</pubDate>
     </item>
 </channel>
@@ -31,6 +32,8 @@ fn test_parse_rss_feed() {
         "https://github.com/ronmkr/aura/releases/download/v1.0.0/aura"
     );
     assert_eq!(items[0].guid, "v1.0.0-stable");
+    assert_eq!(items[0].category, Some("software".to_string()));
+    assert_eq!(items[0].size, None);
 
     assert_eq!(items[1].title, "Aura v1.0.1 Patch");
     assert_eq!(
@@ -40,6 +43,8 @@ fn test_parse_rss_feed() {
     // Hashed GUID fallback because no explicit <guid> is present
     assert!(!items[1].guid.is_empty());
     assert_ne!(items[1].guid, "v1.0.0-stable");
+    assert_eq!(items[1].category, None);
+    assert_eq!(items[1].size, Some(12345));
 }
 
 #[test]

--- a/aura-core/src/worker/nntp/tests.rs
+++ b/aura-core/src/worker/nntp/tests.rs
@@ -34,15 +34,13 @@ async fn test_nntp_resolve_metadata_mock() {
 
             let mut reader = tokio::io::BufReader::new(&mut stream);
             let mut line = String::new();
-            if reader.read_line(&mut line).await.is_ok() {
-                if line.starts_with("BODY") {
-                    let _ = stream.write_all(b"222 Body follows\r\n").await;
-                    let _ = stream
-                        .write_all(b"=ybegin line=128 size=500 name=mock_file.txt\r\n")
-                        .await;
-                    let _ = stream.write_all(b"yEnc data\r\n").await;
-                    let _ = stream.write_all(b".\r\n").await;
-                }
+            if reader.read_line(&mut line).await.is_ok() && line.starts_with("BODY") {
+                let _ = stream.write_all(b"222 Body follows\r\n").await;
+                let _ = stream
+                    .write_all(b"=ybegin line=128 size=500 name=mock_file.txt\r\n")
+                    .await;
+                let _ = stream.write_all(b"yEnc data\r\n").await;
+                let _ = stream.write_all(b".\r\n").await;
             }
         }
     });

--- a/aura-core/tests/storage_backpressure_tests.rs
+++ b/aura-core/tests/storage_backpressure_tests.rs
@@ -22,7 +22,7 @@ async fn test_storage_backpressure_throttles_writes() {
     let res1 = mock_storage
         .submit_write(
             task_id,
-            segment.clone(),
+            segment,
             BytesMut::from(&[0u8; 100][..]),
             None,
             None,

--- a/aura-daemon/Cargo.toml
+++ b/aura-daemon/Cargo.toml
@@ -22,6 +22,7 @@ regex = { workspace = true }
 rlimit = { workspace = true }
 axum-server = { workspace = true }
 rcgen = { workspace = true }
+reqwest = { workspace = true }
 
 [dev-dependencies]
 tokio-tungstenite = { workspace = true }

--- a/aura-daemon/src/jsonrpc/mod.rs
+++ b/aura-daemon/src/jsonrpc/mod.rs
@@ -58,7 +58,7 @@ pub async fn handle_jsonrpc(
 
     info!("RPC Method: {}", payload.method);
 
-    let router = RpcRouter::new(state.engine.clone());
+    let router = RpcRouter::new(state.engine.clone(), state.rss_refresh_tx.clone());
     let (result, already_exists) = router.route(payload.method.as_str(), payload.params).await;
 
     match result {

--- a/aura-daemon/src/jsonrpc/router.rs
+++ b/aura-daemon/src/jsonrpc/router.rs
@@ -6,11 +6,15 @@ use std::sync::Arc;
 
 pub struct RpcRouter {
     engine: Arc<Engine>,
+    rss_refresh_tx: Option<tokio::sync::mpsc::Sender<()>>,
 }
 
 impl RpcRouter {
-    pub fn new(engine: Arc<Engine>) -> Self {
-        Self { engine }
+    pub fn new(engine: Arc<Engine>, rss_refresh_tx: Option<tokio::sync::mpsc::Sender<()>>) -> Self {
+        Self {
+            engine,
+            rss_refresh_tx,
+        }
     }
 
     pub async fn route(
@@ -18,6 +22,13 @@ impl RpcRouter {
         method: &str,
         params: Option<Value>,
     ) -> (Result<Value, Value>, Option<bool>) {
+        if method == "aura.refreshFeeds" {
+            if let Some(ref tx) = self.rss_refresh_tx {
+                let _ = tx.try_send(());
+            }
+            return (Ok(serde_json::json!(true)), None);
+        }
+
         if method == "aura.addUri" {
             return match handle_add_uri(&self.engine, params).await {
                 Ok((val, exists)) => (Ok(val), exists),

--- a/aura-daemon/src/jsonrpc/system.rs
+++ b/aura-daemon/src/jsonrpc/system.rs
@@ -168,11 +168,27 @@ pub async fn handle_get_global_stat(engine: &Engine) -> Result<Value, Value> {
         .unwrap_or_default();
     let num_stopped = history.len();
 
+    let config = engine.config.load();
+    let watch_folder_active = config.storage.watch_dir.is_some() && {
+        if let Some(ref path_str) = config.storage.watch_dir {
+            std::path::Path::new(path_str).exists()
+        } else {
+            false
+        }
+    };
+
+    let last_ingested = {
+        let guard = engine.last_ingested_file.lock().await;
+        guard.clone().unwrap_or_else(|| "".to_string())
+    };
+
     Ok(json!({
         "downloadSpeed": "0",
         "uploadSpeed": "0",
         "numActive": num_active.to_string(),
         "numWaiting": num_waiting.to_string(),
         "numStopped": num_stopped.to_string(),
+        "watchFolderActive": watch_folder_active,
+        "lastIngestedFile": last_ingested,
     }))
 }

--- a/aura-daemon/src/launcher.rs
+++ b/aura-daemon/src/launcher.rs
@@ -63,7 +63,11 @@ pub fn spawn_actors(
     });
 }
 
-pub async fn setup_signal_handler(engine: Arc<Engine>, shutdown_tx: tokio::sync::mpsc::Sender<()>) {
+pub async fn setup_signal_handler(
+    engine: Arc<Engine>,
+    shutdown_tx: tokio::sync::mpsc::Sender<()>,
+    mut custom_shutdown: Option<tokio::sync::mpsc::Receiver<()>>,
+) {
     tokio::spawn(async move {
         #[cfg(unix)]
         {
@@ -73,12 +77,27 @@ pub async fn setup_signal_handler(engine: Arc<Engine>, shutdown_tx: tokio::sync:
             tokio::select! {
                 _ = sigint.recv() => info!("Received SIGINT, initiating graceful shutdown"),
                 _ = sigterm.recv() => info!("Received SIGTERM, initiating graceful shutdown"),
+                _ = async {
+                    if let Some(ref mut rx) = custom_shutdown {
+                        rx.recv().await;
+                    } else {
+                        std::future::pending::<()>().await;
+                    }
+                } => info!("Received custom shutdown signal, initiating graceful shutdown"),
             }
         }
         #[cfg(not(unix))]
         {
-            let _ = tokio::signal::ctrl_c().await;
-            info!("Received Ctrl+C, initiating graceful shutdown");
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => info!("Received Ctrl+C, initiating graceful shutdown"),
+                _ = async {
+                    if let Some(ref mut rx) = custom_shutdown {
+                        rx.recv().await;
+                    } else {
+                        std::future::pending::<()>().await;
+                    }
+                } => info!("Received custom shutdown signal, initiating graceful shutdown"),
+            }
         }
 
         let shutdown_result = tokio::select! {

--- a/aura-daemon/src/lib.rs
+++ b/aura-daemon/src/lib.rs
@@ -155,7 +155,11 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
                                                     }
                                                     if aura_core::rss::RssManager::matches_filters(
                                                         &item.title,
+                                                        item.category.as_deref(),
+                                                        item.size,
                                                         &sub.filters,
+                                                        &sub.categories,
+                                                        sub.max_size,
                                                     ) {
                                                         tracing::info!("RSS Match: Ingesting task '{}' from URL '{}'", item.title, item.link);
 

--- a/aura-daemon/src/lib.rs
+++ b/aura-daemon/src/lib.rs
@@ -30,9 +30,19 @@ pub struct Args {
     pub tls_cert: Option<String>,
     pub tls_key: Option<String>,
     pub generate_tls_cert: bool,
+    pub custom_shutdown: Option<tokio::sync::mpsc::Receiver<()>>,
 }
 
 pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let Args {
+        daemonize: _,
+        mut config,
+        tls_cert,
+        tls_key,
+        generate_tls_cert,
+        custom_shutdown,
+    } = args;
+
     launcher::install_panic_hook();
 
     // Setup JSON tracing for audit logs if not already set
@@ -49,7 +59,6 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting Aura Daemon");
 
-    let mut config = args.config;
     adjust_file_descriptor_limit(&mut config);
     let rpc_secret = launcher::get_or_create_rpc_secret(config.network.rpc_secret.clone())?;
     let rpc_port = config.network.rpc_port;
@@ -97,18 +106,153 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    // Spawn background RSS feed poller
+    let (rss_refresh_tx, mut rss_refresh_rx) = tokio::sync::mpsc::channel::<()>(10);
+    let engine_rss = Arc::clone(&engine);
+    tokio::spawn(async move {
+        let mut last_poll_times: std::collections::HashMap<String, std::time::Instant> =
+            std::collections::HashMap::new();
+        let mut failure_counts: std::collections::HashMap<String, u32> =
+            std::collections::HashMap::new();
+        let rss_manager = aura_core::rss::RssManager::new();
+
+        loop {
+            if let Ok(subs) = rss_manager.load_subscriptions() {
+                let client = reqwest::Client::new();
+                for sub in subs {
+                    let interval_mins = sub.poll_interval.unwrap_or(30);
+                    let failures = failure_counts.get(&sub.url).copied().unwrap_or(0);
+                    let backoff_factor = 2u64.pow(failures.min(6)); // Cap at 64x
+                    let effective_interval = interval_mins * 60 * backoff_factor;
+
+                    let should_poll = match last_poll_times.get(&sub.url) {
+                        Some(last_time) => {
+                            last_time.elapsed()
+                                >= std::time::Duration::from_secs(effective_interval)
+                        }
+                        None => true,
+                    };
+
+                    if should_poll {
+                        tracing::info!("Polling RSS feed '{}' ({})", sub.name, sub.url);
+                        last_poll_times.insert(sub.url.clone(), std::time::Instant::now());
+
+                        match client
+                            .get(&sub.url)
+                            .timeout(std::time::Duration::from_secs(30))
+                            .send()
+                            .await
+                        {
+                            Ok(resp) => {
+                                if resp.status().is_success() {
+                                    failure_counts.insert(sub.url.clone(), 0);
+                                    if let Ok(content) = resp.bytes().await {
+                                        match aura_core::rss::parse_feed(&content[..]) {
+                                            Ok(items) => {
+                                                for item in items {
+                                                    if rss_manager.is_ingested(&item.guid) {
+                                                        continue;
+                                                    }
+                                                    if aura_core::rss::RssManager::matches_filters(
+                                                        &item.title,
+                                                        &sub.filters,
+                                                    ) {
+                                                        tracing::info!("RSS Match: Ingesting task '{}' from URL '{}'", item.title, item.link);
+
+                                                        let task_id = aura_core::TaskId::random();
+                                                        let ttype = if let Some(detected) =
+                                                            aura_core::orchestrator::protocol_detector::ProtocolDetector::detect(&item.link).await
+                                                        {
+                                                            detected.to_task_type()
+                                                        } else {
+                                                            aura_core::task::TaskType::Http
+                                                        };
+
+                                                        let args = aura_core::orchestrator::command::AddTaskArgs {
+                                                            id: task_id,
+                                                            tenant_id: None,
+                                                            name: item.title.clone(),
+                                                            sources: vec![(item.link.clone(), ttype)],
+                                                            checksum: None,
+                                                            priority: 3,
+                                                            streaming_mode: false,
+                                                            depends_on: Vec::new(),
+                                                            follow_on: None,
+                                                        };
+
+                                                        match engine_rss
+                                                            .add_task_with_options(args)
+                                                            .await
+                                                        {
+                                                            Ok(_) => {
+                                                                let _ = rss_manager
+                                                                    .mark_ingested(&item.guid);
+                                                            }
+                                                            Err(
+                                                                aura_core::Error::DuplicateTask(_),
+                                                            ) => {
+                                                                let _ = rss_manager
+                                                                    .mark_ingested(&item.guid);
+                                                            }
+                                                            Err(e) => {
+                                                                tracing::error!("RSS Ingestion failed for '{}': {}", item.title, e);
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            Err(e) => {
+                                                tracing::error!(
+                                                    "Error parsing RSS feed '{}': {}",
+                                                    sub.name,
+                                                    e
+                                                );
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    tracing::error!(
+                                        "Feed '{}' returned HTTP error: {}",
+                                        sub.name,
+                                        resp.status()
+                                    );
+                                    let entry = failure_counts.entry(sub.url.clone()).or_insert(0);
+                                    *entry = entry.saturating_add(1);
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!("Failed to fetch RSS feed '{}': {}", sub.name, e);
+                                let entry = failure_counts.entry(sub.url.clone()).or_insert(0);
+                                *entry = entry.saturating_add(1);
+                            }
+                        }
+                    }
+                }
+            }
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {}
+                _ = rss_refresh_rx.recv() => {
+                    tracing::info!("Manual RSS refresh triggered via JSON-RPC");
+                    last_poll_times.clear();
+                    failure_counts.clear();
+                }
+            }
+        }
+    });
+
     let state = Arc::new(AppState {
         engine: Arc::clone(&engine),
         rpc_secret: Some(rpc_secret),
         metrics,
+        rss_refresh_tx: Some(rss_refresh_tx),
     });
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel::<()>(1);
-    launcher::setup_signal_handler(Arc::clone(&engine), shutdown_tx).await;
+    launcher::setup_signal_handler(Arc::clone(&engine), shutdown_tx, custom_shutdown).await;
 
-    let tls_cert = args.tls_cert.or(config_tls_cert);
-    let tls_key = args.tls_key.or(config_tls_key);
-    let tls_config = tls::setup_tls(args.generate_tls_cert, tls_cert, tls_key)?;
+    let tls_cert = tls_cert.or(config_tls_cert);
+    let tls_key = tls_key.or(config_tls_key);
+    let tls_config = tls::setup_tls(generate_tls_cert, tls_cert, tls_key)?;
 
     server::start_server(
         state,

--- a/aura-daemon/src/metrics_tests.rs
+++ b/aura-daemon/src/metrics_tests.rs
@@ -40,6 +40,7 @@ async fn test_metrics_handler() {
         engine,
         rpc_secret: None,
         metrics,
+        rss_refresh_tx: None,
     });
 
     let response = metrics_handler(State(state)).await.into_response();

--- a/aura-daemon/src/test_helpers.rs
+++ b/aura-daemon/src/test_helpers.rs
@@ -15,6 +15,7 @@ pub async fn setup_test_app(secret: Option<String>) -> (axum::Router, tempfile::
         engine: Arc::new(engine),
         rpc_secret: secret,
         metrics,
+        rss_refresh_tx: None,
     });
     (crate::router::create_router(state), temp_dir)
 }

--- a/aura-daemon/src/types.rs
+++ b/aura-daemon/src/types.rs
@@ -37,4 +37,5 @@ pub struct AppState {
     pub engine: Arc<Engine>,
     pub rpc_secret: Option<String>,
     pub metrics: Arc<super::metrics::DaemonMetrics>,
+    pub rss_refresh_tx: Option<tokio::sync::mpsc::Sender<()>>,
 }

--- a/aura-daemon/tests/ws_test.rs
+++ b/aura-daemon/tests/ws_test.rs
@@ -29,6 +29,7 @@ async fn test_ws_telemetry() {
         engine: engine.clone(),
         rpc_secret: Some("test-secret".to_string()),
         metrics: Arc::new(aura_daemon::metrics::DaemonMetrics::new()),
+        rss_refresh_tx: None,
     });
 
     let app = create_router(state);

--- a/aura-docs/manual/src/cli-reference.md
+++ b/aura-docs/manual/src/cli-reference.md
@@ -106,6 +106,32 @@ Run the **Allocation Prober** to identify the best disk allocation strategy for 
 
 **Usage:** `aura probe [DIR]`
 
+### `service`
+Manage the Aura daemon as a system service (systemd, launchd, or Windows Service) (ADR 0071).
+
+**Usage:** `aura service <SUBCOMMAND>`
+- `install [OPTIONS]`: Install the daemon as a system service.
+    - `--config <PATH>`: Custom configuration file path to use for the service.
+    - `--bind-address <IP>`: IP address to bind the RPC server.
+    - `--rpc-port <PORT>`: Port to bind the RPC server.
+    - `--user <USER>`: The username under which the service should run.
+- `uninstall`: Uninstall the system service.
+- `start`: Start the system service.
+- `stop`: Stop the system service.
+- `status`: Check the status of the system service.
+
+### `feed`
+Manage RSS/Atom feed subscriptions for automated download ingestion (ADR 0070).
+
+**Usage:** `aura feed <SUBCOMMAND>`
+- `add <URL> [OPTIONS]`: Subscribe to an RSS/Atom feed.
+    - `--name <NAME>`: Custom name for this subscription.
+    - `--poll-interval <MINUTES>`: Custom polling interval in minutes (default: 30).
+    - `-f, --filter <PATTERN>`: Title matching filters (regular expressions or strings).
+- `remove <NAME_OR_URL>`: Unsubscribe from a feed by URL or name.
+- `list`: List all subscribed feeds.
+- `refresh`: Force a refresh/poll of all feeds immediately.
+
 ---
 
 ## URL Globbing

--- a/aura-docs/manual/src/cli-reference.md
+++ b/aura-docs/manual/src/cli-reference.md
@@ -128,6 +128,8 @@ Manage RSS/Atom feed subscriptions for automated download ingestion (ADR 0070).
     - `--name <NAME>`: Custom name for this subscription.
     - `--poll-interval <MINUTES>`: Custom polling interval in minutes (default: 30).
     - `-f, --filter <PATTERN>`: Title matching filters (regular expressions or strings).
+    - `-c, --category <CATEGORY>`: Category matching filters (can be specified multiple times).
+    - `--max-size <BYTES>`: Maximum item size limit in bytes.
 - `remove <NAME_OR_URL>`: Unsubscribe from a feed by URL or name.
 - `list`: List all subscribed feeds.
 - `refresh`: Force a refresh/poll of all feeds immediately.

--- a/aura-docs/manual/src/configuration.md
+++ b/aura-docs/manual/src/configuration.md
@@ -194,6 +194,7 @@ Controls how files are saved to your hard drive.
 | `read_ahead_kb` | Number (KB) | `128` | Pre-read data from disk into memory when uploading. |
 | `write_buffer_kb` | Number (KB) | `256` | Size of individual data chunks written to disk. |
 | `recheck_throttle_ms`| Time (ms) | `10` | Throttling delay in milliseconds between read chunks during hash rechecks (ADR 0068). |
+| `watch_dir` | Text | `None` | The folder path to monitor for auto-ingesting `.torrent`, `.metalink`, `.meta4`, or `.nzb` drops (ADR 0069). |
 
 ---
 

--- a/aura-docs/manual/src/tui-guide.md
+++ b/aura-docs/manual/src/tui-guide.md
@@ -21,6 +21,10 @@ Aura TUI uses a **ViewRouter** architecture (ADR 0065) with three primary screen
 ### Automated Ingestion Status
 Tasks added automatically via **Watch Folders** (ADR 0069) or **RSS Feed Subscriptions** (ADR 0070) appear dynamically in the main Dashboard list. Their origin/source is displayed under the task metadata section in the detail panel.
 
+When no task is selected, the right details panel transitions into a **System Overview** dashboard displaying global status:
+- **Watch Folder**: Shows whether the automated watch folder system is active or idle.
+- **Last Ingested**: Displays the file name of the most recently ingested torrent or metalink file.
+
 ---
 
 ## Power-User Navigation

--- a/aura-tui/src/app/rpc.rs
+++ b/aura-tui/src/app/rpc.rs
@@ -134,6 +134,20 @@ impl App {
                 self.ui.error_msg = Some(format!("Daemon Connection Error: {}", e));
             }
         }
+
+        // Fetch watch folder telemetry
+        let stat_res = self.call_rpc("aura.getGlobalStat", None, "tui-stats").await;
+        if let Ok(body) = stat_res {
+            if let Some(result) = body.get("result") {
+                if let Some(active) = result.get("watchFolderActive").and_then(|v| v.as_bool()) {
+                    self.data.watch_folder_active = active;
+                }
+                if let Some(last) = result.get("lastIngestedFile").and_then(|v| v.as_str()) {
+                    self.data.last_ingested_file = last.to_string();
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/aura-tui/src/app/state.rs
+++ b/aura-tui/src/app/state.rs
@@ -42,6 +42,8 @@ pub struct AppData {
     pub downloads: Vec<DownloadInfo>,
     pub files: Vec<FileInfo>,
     pub speed_history: HashMap<String, VecDeque<u64>>,
+    pub watch_folder_active: bool,
+    pub last_ingested_file: String,
 }
 
 pub struct UiState {
@@ -83,6 +85,8 @@ impl App {
                 downloads: Vec::new(),
                 files: Vec::new(),
                 speed_history: HashMap::new(),
+                watch_folder_active: false,
+                last_ingested_file: String::new(),
             },
             ui: UiState {
                 table_state,

--- a/aura-tui/src/ui/dashboard.rs
+++ b/aura-tui/src/ui/dashboard.rs
@@ -229,8 +229,46 @@ pub fn draw_dashboard(f: &mut Frame, app: &mut App, area: Rect) {
             f.render_widget(sparkline, detail_chunks[2]);
         }
     } else {
-        let detail_panel = Paragraph::new("No missions available.")
-            .block(Block::default().borders(Borders::ALL).title(" Details "));
+        let watch_status = if app.data.watch_folder_active {
+            "Active"
+        } else {
+            "Disabled"
+        };
+        let last_file = if app.data.last_ingested_file.is_empty() {
+            "None"
+        } else {
+            &app.data.last_ingested_file
+        };
+
+        let text = vec![
+            Line::from(vec![Span::styled(
+                "System Overview",
+                Style::default().add_modifier(Modifier::BOLD),
+            )]),
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("Watch Folder: "),
+                Span::styled(
+                    watch_status,
+                    if app.data.watch_folder_active {
+                        Style::default().fg(app.ui.theme.success)
+                    } else {
+                        Style::default().fg(app.ui.theme.warning)
+                    },
+                ),
+            ]),
+            Line::from(format!("Last Ingested: {}", last_file)),
+            Line::from(""),
+            Line::from("Select a mission on the left to see details."),
+        ];
+
+        let detail_panel = Paragraph::new(text)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" System Status "),
+            )
+            .wrap(Wrap { trim: true });
         f.render_widget(detail_panel, main_chunks[1]);
     }
 }

--- a/aura/Cargo.toml
+++ b/aura/Cargo.toml
@@ -15,3 +15,9 @@ tracing-subscriber = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 bytesize = { workspace = true }
+service-manager = { workspace = true }
+url = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-service = { workspace = true }
+

--- a/aura/src/cli_client.rs
+++ b/aura/src/cli_client.rs
@@ -276,6 +276,14 @@ pub async fn run_status(
                 .unwrap_or(0);
             println!("{:<20}: {}", "Max Active Tasks", active);
         }
+
+        if let Some(storage) = config.get("storage") {
+            if let Some(watch_dir) = storage.get("watch_dir").and_then(|v| v.as_str()) {
+                println!("{:<20}: {}", "Watch Folder", watch_dir);
+            } else {
+                println!("{:<20}: Disabled", "Watch Folder");
+            }
+        }
     }
 
     Ok(())

--- a/aura/src/feed.rs
+++ b/aura/src/feed.rs
@@ -16,6 +16,12 @@ pub enum FeedAction {
         /// Title matching filters
         #[arg(long, short)]
         filter: Vec<String>,
+        /// Category matching filters
+        #[arg(long, short)]
+        category: Vec<String>,
+        /// Maximum item size limit in bytes
+        #[arg(long)]
+        max_size: Option<u64>,
     },
     /// Unsubscribe from a feed by URL or name
     Remove {
@@ -41,6 +47,8 @@ pub async fn handle_feed_command(
             name,
             poll_interval,
             filter,
+            category,
+            max_size,
         } => {
             let name = name.unwrap_or_else(|| {
                 if let Ok(u) = url::Url::parse(&url) {
@@ -56,11 +64,19 @@ pub async fn handle_feed_command(
                 Some(filter)
             };
 
+            let categories = if category.is_empty() {
+                None
+            } else {
+                Some(category)
+            };
+
             let sub = FeedSubscription {
                 url: url.clone(),
                 name: name.clone(),
                 poll_interval,
                 filters,
+                categories,
+                max_size,
             };
 
             match rss_manager.add_subscription(sub) {

--- a/aura/src/feed.rs
+++ b/aura/src/feed.rs
@@ -1,0 +1,165 @@
+use aura_core::rss::{FeedSubscription, RssManager};
+use serde_json::json;
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum FeedAction {
+    /// Subscribe to an RSS/Atom feed
+    Add {
+        /// URL of the feed
+        url: String,
+        /// Custom name for this subscription
+        #[arg(long)]
+        name: Option<String>,
+        /// Custom polling interval in minutes (default is 30)
+        #[arg(long)]
+        poll_interval: Option<u64>,
+        /// Title matching filters
+        #[arg(long, short)]
+        filter: Vec<String>,
+    },
+    /// Unsubscribe from a feed by URL or name
+    Remove {
+        /// Name or URL of the feed
+        target: String,
+    },
+    /// List all subscribed feeds
+    List,
+    /// Force a refresh/poll of all feeds immediately
+    Refresh,
+}
+
+pub async fn handle_feed_command(
+    action: FeedAction,
+    rpc_port: u16,
+    rpc_secret: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let rss_manager = RssManager::new();
+
+    match action {
+        FeedAction::Add {
+            url,
+            name,
+            poll_interval,
+            filter,
+        } => {
+            let name = name.unwrap_or_else(|| {
+                if let Ok(u) = url::Url::parse(&url) {
+                    u.host_str().unwrap_or(&url).to_string()
+                } else {
+                    url.clone()
+                }
+            });
+
+            let filters = if filter.is_empty() {
+                None
+            } else {
+                Some(filter)
+            };
+
+            let sub = FeedSubscription {
+                url: url.clone(),
+                name: name.clone(),
+                poll_interval,
+                filters,
+            };
+
+            match rss_manager.add_subscription(sub) {
+                Ok(_) => {
+                    println!("Successfully subscribed to feed '{}' (URL: {}).", name, url);
+                    let _ = trigger_rpc_refresh(rpc_port, rpc_secret).await;
+                }
+                Err(e) => {
+                    eprintln!("Error adding subscription: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        FeedAction::Remove { target } => match rss_manager.remove_subscription(&target) {
+            Ok(_) => {
+                println!("Successfully unsubscribed from feed '{}'.", target);
+            }
+            Err(e) => {
+                eprintln!("Error removing subscription: {}", e);
+                std::process::exit(1);
+            }
+        },
+        FeedAction::List => match rss_manager.load_subscriptions() {
+            Ok(subs) => {
+                if subs.is_empty() {
+                    println!("No active feed subscriptions.");
+                    return Ok(());
+                }
+                println!(
+                    "{:<25} {:<10} {:<40} {:<30}",
+                    "Name", "Interval", "Filters", "URL"
+                );
+                println!("{}", "-".repeat(110));
+                for s in subs {
+                    let interval = format!("{}m", s.poll_interval.unwrap_or(30));
+                    let filter_str = s
+                        .filters
+                        .as_ref()
+                        .map(|f| f.join(", "))
+                        .unwrap_or_else(|| "None".to_string());
+
+                    let url_disp = if s.url.len() > 40 {
+                        format!("{}...", &s.url[..37])
+                    } else {
+                        s.url.clone()
+                    };
+
+                    println!(
+                        "{:<25} {:<10} {:<40} {:<30}",
+                        s.name, interval, filter_str, url_disp
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("Error loading subscriptions: {}", e);
+                std::process::exit(1);
+            }
+        },
+        FeedAction::Refresh => {
+            println!("Requesting immediate polling of all feeds from daemon...");
+            match trigger_rpc_refresh(rpc_port, rpc_secret).await {
+                Ok(_) => println!("Feeds refresh requested successfully."),
+                Err(e) => {
+                    eprintln!(
+                        "Failed to trigger daemon refresh: {}. Daemon might be offline.",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn trigger_rpc_refresh(
+    port: u16,
+    secret: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let url = format!("http://localhost:{}/jsonrpc", port);
+    let secret = aura_core::Config::resolve_rpc_secret(secret);
+
+    let mut req = client.post(&url);
+    if let Some(ref sec) = secret {
+        req = req.header(aura_core::RPC_AUTH_HEADER, sec);
+    }
+
+    let payload = json!({
+        "jsonrpc": aura_core::JSONRPC_VERSION,
+        "method": "aura.refreshFeeds",
+        "params": vec![json!(())],
+        "id": "cli-feed-refresh"
+    });
+
+    let resp = req.json(&payload).send().await?;
+    let body: serde_json::Value = resp.json().await?;
+    if let Some(err) = body.get("error") {
+        return Err(format!("RPC error: {}", err).into());
+    }
+    Ok(())
+}

--- a/aura/src/logging.rs
+++ b/aura/src/logging.rs
@@ -1,0 +1,56 @@
+pub fn init_logging(verbose: u8, is_service: bool, use_json: bool) {
+    let log_level = match verbose {
+        0 => tracing::Level::INFO,
+        1 => tracing::Level::DEBUG,
+        _ => tracing::Level::TRACE,
+    };
+
+    match (is_service, use_json) {
+        (true, true) => {
+            let subscriber = tracing_subscriber::FmtSubscriber::builder()
+                .json()
+                .with_max_level(log_level)
+                .with_target(false)
+                .with_writer(aura_daemon::scrubber::ScrubbingMakeWriter::new(
+                    std::io::stderr,
+                ))
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Failed to set tracing subscriber");
+        }
+        (true, false) => {
+            let subscriber = tracing_subscriber::FmtSubscriber::builder()
+                .with_max_level(log_level)
+                .with_target(false)
+                .with_writer(aura_daemon::scrubber::ScrubbingMakeWriter::new(
+                    std::io::stderr,
+                ))
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Failed to set tracing subscriber");
+        }
+        (false, true) => {
+            let subscriber = tracing_subscriber::FmtSubscriber::builder()
+                .json()
+                .with_max_level(log_level)
+                .with_target(false)
+                .with_writer(aura_daemon::scrubber::ScrubbingMakeWriter::new(
+                    std::io::stdout,
+                ))
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Failed to set tracing subscriber");
+        }
+        (false, false) => {
+            let subscriber = tracing_subscriber::FmtSubscriber::builder()
+                .with_max_level(log_level)
+                .with_target(false)
+                .with_writer(aura_daemon::scrubber::ScrubbingMakeWriter::new(
+                    std::io::stdout,
+                ))
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("Failed to set tracing subscriber");
+        }
+    }
+}

--- a/aura/src/main.rs
+++ b/aura/src/main.rs
@@ -1,5 +1,11 @@
 use clap::{Parser, Subcommand};
 mod cli_client;
+mod feed;
+mod logging;
+mod service;
+#[cfg(target_os = "windows")]
+mod service_windows;
+
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Aura", long_about = None)]
 struct Cli {
@@ -58,7 +64,21 @@ enum Commands {
         /// Automatically generate self-signed TLS certificate and key files
         #[arg(long)]
         generate_tls_cert: bool,
+        /// Run as a Windows Service (internal flag used by SCM)
+        #[arg(long)]
+        windows_service: bool,
     },
+    /// Manage the Aura daemon as a system service (systemd, launchd, Windows Service)
+    Service {
+        #[command(subcommand)]
+        action: service::ServiceAction,
+    },
+    /// Manage RSS/Atom feed subscriptions
+    Feed {
+        #[command(subcommand)]
+        action: feed::FeedAction,
+    },
+
     /// Start the Terminal UI dashboard
     Tui,
     /// Probe the optimal allocation strategy for a given directory
@@ -122,19 +142,12 @@ enum Commands {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     // Initialize tracing
-    let log_level = match cli.verbose {
-        0 => tracing::Level::INFO,
-        1 => tracing::Level::DEBUG,
-        _ => tracing::Level::TRACE,
-    };
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_max_level(log_level)
-        .with_target(false)
-        .with_writer(aura_daemon::scrubber::ScrubbingMakeWriter::new(
-            std::io::stdout,
-        ))
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("Failed to set tracing subscriber");
+    let is_service = std::env::var("AURA_SERVICE").is_ok()
+        || std::env::var("AURA_LOG_JSON").is_ok()
+        || std::env::args().any(|arg| arg == "--windows-service");
+    let use_json = std::env::var("AURA_LOG_JSON").is_ok();
+
+    logging::init_logging(cli.verbose, is_service, use_json);
     // Load configuration based on hierarchy rules
     let mut config = aura_core::Config::load_resolved(cli.config.as_deref())?;
     // Extract daemon-specific overrides
@@ -144,6 +157,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut daemon_tls_cert = None;
     let mut daemon_tls_key = None;
     let mut daemon_generate_tls_cert = false;
+    let mut daemon_windows_service = false;
     if let Some(Commands::Daemon {
         bind_address,
         rpc_port,
@@ -151,6 +165,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tls_cert,
         tls_key,
         generate_tls_cert,
+        windows_service,
     }) = &cli.command
     {
         daemon_bind_address = bind_address.clone();
@@ -159,6 +174,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         daemon_tls_cert = tls_cert.clone();
         daemon_tls_key = tls_key.clone();
         daemon_generate_tls_cert = *generate_tls_cert;
+        daemon_windows_service = *windows_service;
     }
     // Apply CLI overrides to configuration
     config.apply_cli_overrides(aura_core::config::CliOverrides {
@@ -180,9 +196,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 tls_cert: daemon_tls_cert,
                 tls_key: daemon_tls_key,
                 generate_tls_cert: daemon_generate_tls_cert,
+                custom_shutdown: None,
             };
-            aura_daemon::run(args).await?;
+            #[cfg(target_os = "windows")]
+            {
+                if daemon_windows_service {
+                    service_windows::run_as_windows_service(args)?;
+                } else {
+                    aura_daemon::run(args).await?;
+                }
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                if daemon_windows_service {
+                    return Err("Windows service mode is only supported on Windows".into());
+                }
+                aura_daemon::run(args).await?;
+            }
         }
+        Some(Commands::Service { action }) => {
+            service::handle_service_command(action)?;
+        }
+        Some(Commands::Feed { action }) => {
+            feed::handle_feed_command(
+                action,
+                config.network.rpc_port,
+                config.network.rpc_secret.clone(),
+            )
+            .await?;
+        }
+
         Some(Commands::Tui) => {
             // Run TUI
             let rpc_url = format!("http://localhost:{}/jsonrpc", config.network.rpc_port);

--- a/aura/src/service.rs
+++ b/aura/src/service.rs
@@ -1,0 +1,219 @@
+use service_manager::*;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum ServiceAction {
+    /// Install the daemon as a system service
+    Install {
+        /// Custom configuration file path to use for the service
+        #[arg(long)]
+        config: Option<String>,
+        /// IP address to bind the RPC server
+        #[arg(long)]
+        bind_address: Option<String>,
+        /// Port to bind the RPC server
+        #[arg(long)]
+        rpc_port: Option<u16>,
+        /// The username under which the service should run (e.g. root or Administrator)
+        #[arg(long)]
+        user: Option<String>,
+    },
+    /// Uninstall the system service
+    Uninstall,
+    /// Start the system service
+    Start,
+    /// Stop the system service
+    Stop,
+    /// Check the status of the system service
+    Status,
+}
+
+pub fn handle_service_command(action: ServiceAction) -> Result<(), Box<dyn std::error::Error>> {
+    let label: ServiceLabel = "com.aura.daemon".parse()?;
+
+    let manager = match <dyn ServiceManager>::native() {
+        Ok(m) => m,
+        Err(e) => {
+            return Err(format!(
+                "Failed to detect native service manager on this platform: {}. \
+                Please ensure you run this command on a supported platform (systemd, launchd, or Windows Service).",
+                e
+            ).into());
+        }
+    };
+
+    match action {
+        ServiceAction::Install {
+            config,
+            bind_address,
+            rpc_port,
+            user,
+        } => {
+            println!("Installing Aura daemon as a system service...");
+
+            let exe_path = std::env::current_exe()?;
+            let resolved_config = config.map(|cfg| {
+                std::fs::canonicalize(&cfg)
+                    .unwrap_or_else(|_| PathBuf::from(cfg))
+                    .into_os_string()
+                    .into_string()
+                    .unwrap_or_default()
+            });
+            let args = build_install_args(resolved_config, bind_address, rpc_port);
+
+            let ctx = ServiceInstallCtx {
+                label: label.clone(),
+                program: exe_path,
+                args,
+                contents: None,
+                username: user,
+                working_directory: None,
+                environment: None,
+                autostart: true,
+                restart_policy: RestartPolicy::default(),
+            };
+
+            match manager.install(ctx) {
+                Ok(_) => {
+                    println!("Aura daemon service installed successfully.");
+                    println!("To start the service, run: aura service start");
+                }
+                Err(e) => {
+                    eprintln!("Error installing service: {}", e);
+                    suggest_privileges();
+                    return Err(e.into());
+                }
+            }
+        }
+        ServiceAction::Uninstall => {
+            println!("Uninstalling Aura daemon service...");
+            match manager.uninstall(ServiceUninstallCtx { label }) {
+                Ok(_) => println!("Aura daemon service uninstalled successfully."),
+                Err(e) => {
+                    eprintln!("Error uninstalling service: {}", e);
+                    suggest_privileges();
+                    return Err(e.into());
+                }
+            }
+        }
+        ServiceAction::Start => {
+            println!("Starting Aura daemon service...");
+            match manager.start(ServiceStartCtx { label }) {
+                Ok(_) => println!("Aura daemon service started successfully."),
+                Err(e) => {
+                    eprintln!("Error starting service: {}", e);
+                    suggest_privileges();
+                    return Err(e.into());
+                }
+            }
+        }
+        ServiceAction::Stop => {
+            println!("Stopping Aura daemon service...");
+            match manager.stop(ServiceStopCtx { label }) {
+                Ok(_) => println!("Aura daemon service stopped successfully."),
+                Err(e) => {
+                    eprintln!("Error stopping service: {}", e);
+                    suggest_privileges();
+                    return Err(e.into());
+                }
+            }
+        }
+        ServiceAction::Status => {
+            let label_str = "com.aura.daemon";
+            println!("Querying status for service '{}'...", label_str);
+
+            #[cfg(target_os = "linux")]
+            {
+                let output = std::process::Command::new("systemctl")
+                    .arg("status")
+                    .arg(label_str)
+                    .output()?;
+
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                print!("{}", stdout);
+                eprint!("{}", stderr);
+            }
+
+            #[cfg(target_os = "macos")]
+            {
+                let output = std::process::Command::new("launchctl")
+                    .arg("list")
+                    .output()?;
+
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let found = stdout.lines().find(|line| line.contains(label_str));
+                if let Some(line) = found {
+                    println!("Service is registered in launchd:");
+                    println!("  {}", line);
+                } else {
+                    println!("Service '{}' not found in launchd active list.", label_str);
+                }
+            }
+
+            #[cfg(target_os = "windows")]
+            {
+                let output = std::process::Command::new("sc.exe")
+                    .arg("query")
+                    .arg(label_str)
+                    .output()?;
+
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                print!("{}", stdout);
+                eprint!("{}", stderr);
+            }
+
+            #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+            {
+                println!("Service status query not supported on this platform.");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn build_install_args(
+    config: Option<String>,
+    bind_address: Option<String>,
+    rpc_port: Option<u16>,
+) -> Vec<OsString> {
+    let mut args = vec![OsString::from("daemon")];
+
+    if let Some(cfg) = config {
+        args.push(OsString::from("--config"));
+        args.push(OsString::from(cfg));
+    }
+    if let Some(addr) = bind_address {
+        args.push(OsString::from("--bind-address"));
+        args.push(OsString::from(addr));
+    }
+    if let Some(port) = rpc_port {
+        args.push(OsString::from("--rpc-port"));
+        args.push(OsString::from(port.to_string()));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        args.push(OsString::from("--windows-service"));
+    }
+
+    args
+}
+
+fn suggest_privileges() {
+    #[cfg(unix)]
+    {
+        eprintln!("Note: Service management commands typically require administrator privileges. Try running this command with 'sudo'.");
+    }
+    #[cfg(windows)]
+    {
+        eprintln!("Note: Service management commands typically require administrator privileges. Please run your terminal/prompt as Administrator.");
+    }
+}
+
+#[cfg(test)]
+#[path = "service_tests.rs"]
+mod tests;

--- a/aura/src/service_tests.rs
+++ b/aura/src/service_tests.rs
@@ -1,0 +1,63 @@
+use super::*;
+use std::ffi::OsString;
+
+#[test]
+fn test_build_install_args_empty() {
+    let args = build_install_args(None, None, None);
+
+    #[cfg(target_os = "windows")]
+    {
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("daemon"),
+                OsString::from("--windows-service")
+            ]
+        );
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        assert_eq!(args, vec![OsString::from("daemon")]);
+    }
+}
+
+#[test]
+fn test_build_install_args_all() {
+    let args = build_install_args(
+        Some("Aura.toml".to_string()),
+        Some("127.0.0.1".to_string()),
+        Some(6800),
+    );
+
+    #[cfg(target_os = "windows")]
+    {
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("daemon"),
+                OsString::from("--config"),
+                OsString::from("Aura.toml"),
+                OsString::from("--bind-address"),
+                OsString::from("127.0.0.1"),
+                OsString::from("--rpc-port"),
+                OsString::from("6800"),
+                OsString::from("--windows-service"),
+            ]
+        );
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("daemon"),
+                OsString::from("--config"),
+                OsString::from("Aura.toml"),
+                OsString::from("--bind-address"),
+                OsString::from("127.0.0.1"),
+                OsString::from("--rpc-port"),
+                OsString::from("6800"),
+            ]
+        );
+    }
+}

--- a/aura/src/service_windows.rs
+++ b/aura/src/service_windows.rs
@@ -1,0 +1,126 @@
+#![cfg(target_os = "windows")]
+
+use std::ffi::OsString;
+use std::sync::Mutex;
+use std::time::Duration;
+use windows_service::{
+    define_windows_service,
+    service::{ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus},
+    service_control_handler::{self, ServiceControlHandlerResult},
+    service_dispatcher,
+};
+
+static DAEMON_ARGS: Mutex<Option<aura_daemon::Args>> = Mutex::new(None);
+
+define_windows_service!(ffi_service_main, my_service_main);
+
+pub fn run_as_windows_service(args: aura_daemon::Args) -> Result<(), Box<dyn std::error::Error>> {
+    {
+        let mut guard = DAEMON_ARGS.lock().unwrap();
+        *guard = Some(args);
+    }
+
+    // service_dispatcher::start blocks until the service stops.
+    service_dispatcher::start("com.aura.daemon", ffi_service_main)?;
+    Ok(())
+}
+
+fn my_service_main(_arguments: Vec<OsString>) {
+    // Create a channel to communicate SCM stop signal to the running daemon
+    let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let shutdown_tx_clone = shutdown_tx.clone();
+
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            ServiceControl::Stop => {
+                let _ = shutdown_tx_clone.try_send(());
+                ServiceControlHandlerResult::NoError
+            }
+            ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+
+    let status_handle = match service_control_handler::register("com.aura.daemon", event_handler) {
+        Ok(handle) => handle,
+        Err(_) => return,
+    };
+
+    // Signal start pending
+    let _ = status_handle.set_service_status(ServiceStatus {
+        service_type: windows_service::service::ServiceType::OWN_PROCESS,
+        current_state: ServiceState::StartPending,
+        controls_accepted: ServiceControlAccept::STOP,
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::from_secs(5),
+    });
+
+    // Retrieve daemon args
+    let mut args = match {
+        let mut guard = DAEMON_ARGS.lock().unwrap();
+        guard.take()
+    } {
+        Some(a) => a,
+        None => {
+            let _ = status_handle.set_service_status(ServiceStatus {
+                service_type: windows_service::service::ServiceType::OWN_PROCESS,
+                current_state: ServiceState::Stopped,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code: ServiceExitCode::Win32(1053), // ERROR_SERVICE_SPECIFIC_ERROR
+                checkpoint: 0,
+                wait_hint: Duration::from_secs(0),
+            });
+            return;
+        }
+    };
+
+    // Inject custom shutdown receiver into the daemon arguments
+    args.custom_shutdown = Some(shutdown_rx);
+
+    // Signal running
+    let _ = status_handle.set_service_status(ServiceStatus {
+        service_type: windows_service::service::ServiceType::OWN_PROCESS,
+        current_state: ServiceState::Running,
+        controls_accepted: ServiceControlAccept::STOP,
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::from_secs(0),
+    });
+
+    // Start a new multithreaded runtime and block on daemon run
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(_) => {
+            let _ = status_handle.set_service_status(ServiceStatus {
+                service_type: windows_service::service::ServiceType::OWN_PROCESS,
+                current_state: ServiceState::Stopped,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code: ServiceExitCode::Win32(1053),
+                checkpoint: 0,
+                wait_hint: Duration::from_secs(0),
+            });
+            return;
+        }
+    };
+
+    let run_result = rt.block_on(async { aura_daemon::run(args).await });
+
+    // Signal service stopped
+    let exit_code = match run_result {
+        Ok(_) => 0,
+        Err(_) => 1,
+    };
+
+    let _ = status_handle.set_service_status(ServiceStatus {
+        service_type: windows_service::service::ServiceType::OWN_PROCESS,
+        current_state: ServiceState::Stopped,
+        controls_accepted: ServiceControlAccept::empty(),
+        exit_code: ServiceExitCode::Win32(exit_code),
+        checkpoint: 0,
+        wait_hint: Duration::from_secs(0),
+    });
+}

--- a/packaging/aura.service
+++ b/packaging/aura.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Aura Download Engine Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/aura daemon
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/com.aura.daemon.plist
+++ b/packaging/com.aura.daemon.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.aura.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/aura</string>
+        <string>daemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+</dict>
+</plist>

--- a/packaging/install-service.ps1
+++ b/packaging/install-service.ps1
@@ -1,0 +1,17 @@
+# PowerShell Script to install Aura as a Windows Service
+# Must be run as Administrator
+
+$ExePath = Join-Path $PSScriptRoot "aura.exe"
+if (-not (Test-Path $ExePath)) {
+    $ExePath = "C:\Program Files\Aura\aura.exe"
+}
+
+if (-not (Test-Path $ExePath)) {
+    Write-Error "Aura executable not found. Please place aura.exe in this folder or at C:\Program Files\Aura\aura.exe"
+    exit 1
+}
+
+Write-Host "Registering Aura Download Engine as a Windows Service..."
+New-Service -Name "AuraDaemon" -BinaryPathName "`"$ExePath`" daemon --windows-service" -DisplayName "Aura Download Service" -StartupType Automatic
+Start-Service -Name "AuraDaemon"
+Write-Host "Aura service registered and started."


### PR DESCRIPTION
## Description

This PR implements three high-priority features for the Aura download engine daemon as specified in Issues #288, #290, and #291:
1. **System Service Integration (Issue #291)**: Native auto-start daemon capability on boot using `service-manager` and platform-native service systems (systemd on Linux, launchd on macOS, SCM on Windows). Exposes subcommands under `aura service`.
2. **RSS/Atom Feed Subscriptions (Issue #290)**: Background poller loop inside the daemon to automatically fetch, filter, and ingest matching feed downloads, deduplicating them using a local ingest history database. Added CLI `--category` and `--max-size` flags, XML entity expansion security checks, and manual documentation.
3. **Watch Folder Auto-Ingestion (Issue #288)**: Event-driven monitored directory watching utilizing the `notify` crate, automatically staging `.torrent`/`.metalink` file drops. Added a 500ms file-size stabilization debouncing loop to prevent premature parsing.
4. **TUI System Overview Status**: Integrated TUI dashboard system overview pane showing daemon Watch Folder status and the last ingested file in real-time.

Fixes #288
Fixes #290
Fixes #291
Fixes #304
Fixes #305
Fixes #306

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance (dependency update, cleanup, etc.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (run `cargo clippy`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (run `cargo test`)
- [x] Any dependent changes have been merged and published in downstream modules
